### PR TITLE
Change categories for fgsl and SciFortran

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -504,13 +504,13 @@
 - name: fgsl
   github: reinh-bader/fgsl
   description: Fortran interface to the GNU Scientific Library 
-  categories: numerical scientific
+  categories: numerical interfaces
   tags: 
 
 - name: SciFortran
   github: aamaricci/SciFortran
   description: collection of fortran modules and procedures for scientific calculations.
-  categories: numerical scientific
+  categories: numerical
   tags: 
   version: none
 


### PR DESCRIPTION
They are both SciPy like libraries, and so should belong into
"numerical". The Scientific Codes category I think should be reserved
for more of end user applications or physics solvers, not purely
numerical libraries.