### PR TITLE
Remove OpenBLAS

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -441,12 +441,6 @@
 
 # --- Numerical libraries ---
 
-- name: OpenBLAS
-  github: xianyi/OpenBLAS
-  description: Optimized BLAS library based on GotoBLAS2
-  categories: numerical
-  tags: blas linear algebra
-
 - name: LAPACK
   github: xianyi/OpenBLAS
   description: Routines for numerical linear algebra


### PR DESCRIPTION
The package does not satisfy our criteria, in particular:

Relevance

* the package must be primarily implemented in Fortran
* or provide a complete Fortran interface to an existing package
* or be purposed solely towards software development in Fortran.

None of these apply. They do not provide a Fortran interface to another
package, and OpenBLAS is not purposed solely towards software
development in Fortran. Regarding the first bullet point, the package is
primarily developed in assembly, all new code is in assembly. Fortran is
not the primary implementation language, despite technically having more
lines than their implementation language (assembly).
They have a lot of Fortran code (in fact the majority of lines) because
they have several copies of LAPACK. They keep applying fixes from
reference LAPACK (which is already included in our index, so we should
not be including it twice). OpenBLAS is in the same category as SciPy.
They copied a mature Fortran project / code, but use a different
language to further develop the package (assembly and Python
respectively). In the SciPy's case, the Python code now has more lines
than Fortran, in OpenBLAS case the assembly code does not yet have more
lines, but eventually it will.

Uniqueness

* the package shall not be a fork or minor revision of existing packages

As far as Fortran is concerned, this package is just a fork of LAPACK.
There is no new Fortran code that isn't in LAPACK that other projects
could use.

----

We can think (see #72) if we should have categories for projects that happen to
have Fortran code included, even it is not further developed. OpenBLAS
and SciPy would be two major libraries to include there. Until then, we
should remove OpenBLAS from our listing.