### PR TITLE
Fix broken getting started link from tutorial -> learn

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@ title: Home
       <h3>Write Fortran software</h3>
       <p>
       Or just write Fortran software for your research, business, or schoolwork.
-      You can learn how to get started <a href="/tutorial/">here</a>.
+      You can learn how to get started <a href="/learn/">here</a>.
       </p>
     </div>
 


### PR DESCRIPTION
It seems the getting started link in the home page (https://fortran-lang.org/) above footer is broken as it still points to `tutorial/`, which was removed in this commit: https://github.com/fortran-lang/fortran-lang.org/commit/2adc5eba834fc34e90a7c0b216449db2fcecfdea#diff-94d9a081cd1256334373c8ca6fb6276c