### PR TITLE
 adding the ParaMonte library 

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -489,7 +489,7 @@
 
 - name: ParaMonte
   github: cdslaborg/paramonte
-  description: ParaMonte is a well-tested general-purpose open-source high-performance MPI/Coarray-parallel Monte Carlo simulation library implemented in the 2018-standard-complaint Fortran programming language, currently with interfaces to the C/C++/Fortran/MATLAB/Python programming languages.
+  description: A general-purpose high-performance MPI/Coarray-parallel Monte Carlo simulation library implemented in Fortran 2018 with interfaces to C/C++/Fortran/MATLAB/Python 
   categories: numerical
   tags: parallel mpi coarray monte carlo mcmc c cpp matlab python statistics bayesian stochastic optimization sampling integration machine learning
   version: 1.0.0


### PR DESCRIPTION
This commit adds the ParaMonte library to the list of Fortran numerical libraries. ParaMonte is a well-tested general-purpose open-source high-performance MPI/Coarray-parallel Monte Carlo simulation library implemented in the 2018-standard-complaint Fortran programming language, currently with interfaces to the C/C++/Fortran/MATLAB/Python programming languages. The project's documentation is available at: https://github.com/cdslaborg/paramonte