### PR TITLE
Add Doctor Fortran blog to learning.yml

### DIFF
--- a/_data/learning.yml
+++ b/_data/learning.yml
@@ -67,8 +67,10 @@ reference-links:
   - name: "Scivision Fortran 2018 Examples"
     url: https://github.com/scivision/fortran2018-examples
     description: A github repository containing code samples for various Fortran 2018 features
-
-
+    
+  - name: "Doctor Fortran Blog"
+    url: https:/stevelionel.com/drfortran
+    description: A collection of posts on interesting or little-understood aspects of the Fortran language    
 
 
 # Print books listed at the bottom of the 'Learn' landing page

--- a/_data/learning.yml
+++ b/_data/learning.yml
@@ -69,7 +69,7 @@ reference-links:
     description: A github repository containing code samples for various Fortran 2018 features
     
   - name: "Doctor Fortran Blog"
-    url: https:/stevelionel.com/drfortran
+    url: https://stevelionel.com/drfortran
     description: A collection of posts on interesting or little-understood aspects of the Fortran language    
 
 


### PR DESCRIPTION
Add Steve Lionel's "Doctor Fortran" blog to the list of external resources on the Fortran language