### PR TITLE
Expand do loops with cycle and exit

### DIFF
--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -147,9 +147,6 @@ The `do concurrent` loop is used to explicitly specify that the _inside of the l
 that any loop iteration does not depend on the prior execution of other loop iterations. It is also necessary that any state changes that may occur must only happen within each `do concurrent` loop. 
 These requirements place restrictions on what can be placed within the loop body.
 
-However, the true nature of the `do concurrent` construct may not be fully understood by the paragraph above. `do concurrent`
-was specifically created to tell the compiler that it may parallelize/_SIMD_ what is inside the `do concurrent`,
-which could potentially lead to faster code. The intention of the programmer is also conveyed more clearly.
 
 {% include important.html content="`do concurrent` is not a basic feature of Fortran. The explanation given does not detail
 all the requirements that need to be met in order to write a correct `do concurrent` loop. Compilers are also free to do as they see fit,

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -35,13 +35,13 @@ To form a logical expression the following set of relational operators are avail
 
 as well as the following logical operators:
 
-| Operator &nbsp; | Description                                                          |
-|:---------------------:|----------------------------------------------------------------|
-| `.and.`         | TRUE if both left and right operands are TRUE                        |
-| `.or.`          | TRUE if either left or right or both operands are TRUE               |
-| `.not.`         | TRUE if right operand is FALSE                                       |
-| `.eqv.`         | TRUE if left operand has same logical value as right operand         |
-| `.neqv.`        | TRUE if left operand has the opposite logical value as right operand |
+| Operator &nbsp;       | Description                                                          |
+|:---------------------:|----------------------------------------------------------------------|
+| `.and.`               | TRUE if both left and right operands are TRUE                        |
+| `.or.`                | TRUE if either left or right or both operands are TRUE               |
+| `.not.`               | TRUE if right operand is FALSE                                       |
+| `.eqv.`               | TRUE if left operand has same logical value as right operand         |
+| `.neqv.`              | TRUE if left operand has the opposite logical value as right operand |
 
 <br>
 
@@ -119,19 +119,58 @@ __Example:__ `do` loop with skip
 
 ```fortran
   integer :: i
-  do i=1,10,2    
+  do i=1,10,2
     print *, i   ! Print odd numbers
   end do
 ```
 
+### `do while()`
+
+A condition may be added to a `do` loop with the `while` keyword. The loop will be executed while the condition given
+in `while()` evaluates to `.true.`.
 
 __Example:__ `do while` loop
 
 ```fortran
   integer :: i
   i = 1
-  do while (i<11)   
+  do while (i<11)
     print *, i
     i = i + 1
+  end do
+  ! Here i = 11
+```
+
+### Finer loop control: (`exit`) and (`cycle`)
+
+Most often than not, loops need to be stopped if a condition is met. Fortran presents two reserved words to deal
+with such cases.
+
+`exit` is used to quit the loop prematurely. It is usually enclosed inside an `if`.
+
+__Example__ loop with `exit`
+
+```fortran
+  integer :: i
+  do i=1, 100
+    if (i .gt. 10) then
+      exit ! Stop printing numbers
+    end if
+    print *, i
+  end do
+  ! Here i = 11
+```
+
+On the other hand, `cycle` skips whatever is left of the loop and goes into the next cycle.
+
+__Example__ loop with `cycle`
+
+```fortran
+  integer :: i
+  do i=1,10
+    if (mod(i,2) .eq. 0) then
+	  cycle ! Don't print even numbers
+	end if
+    print *, i
   end do
 ```

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -129,7 +129,7 @@ __Example:__ `do` loop with skip
 A condition may be added to a `do` loop with the `while` keyword. The loop will be executed while the condition given
 in `while()` evaluates to `.true.`.
 
-__Example:__ `do while` loop
+__Example:__ `do while()` loop
 
 ```fortran
   integer :: i
@@ -139,6 +139,33 @@ __Example:__ `do while` loop
     i = i + 1
   end do
   ! Here i = 11
+```
+
+### `do concurrent()`
+
+The `do concurrent` loop is used to specify that the _inside of the loop has no interdependencies_. By this, it is indicated
+that any loop does not depend on the loops before it. It is also necessary that any state changes that may occur must only
+happen within each `do concurrent` loop. Because of these requirements, it is important to be carful with what is written inside the loop.
+
+However, the true nature of the `do concurrent` construct may not be fully understood by the paragraph above. `do concurrent`
+was specifically created to tell the compiler that it may parallelize/_SIMD_ what is inside the `do concurrent`,
+which could potentially lead to faster code. The intention of the programmer is also conveyed more clearly.
+
+{% include important.html content="`do concurrent` is not a basic feature of Fortran. The explanation given does not detail
+all the requirements that need to be met in order to write a correct `do concurrent` loop. Compilers are also free to do as they see fit,
+which means they may not optimize the loop."}
+
+__Example__ `do concurrent()` loop
+
+```fortran
+  real, parameter :: pi = 3.14159265
+  integer, parameter :: n = 10
+  real :: result_sin(n)
+  integer :: i
+  do concurrent (i=1:n) ! Careful, the syntax is slightly different
+    result_sin(i) = sin(i*pi/4.)
+  end do
+  print *, result_sin
 ```
 
 ### Finer loop control: (`exit`) and (`cycle`)
@@ -173,4 +200,23 @@ __Example__ loop with `cycle`
 	end if
     print *, i
   end do
+```
+### Even finer loop control: tags
+
+A recurring case in any programming language is the use of nested loops. Nested loops refer to loops that exist within another loop. Fortran allows the programmer to _tag_ or _name_ each loop. If loops are tagged, there are two potential benefits:
+1. The readability of the code may be improved (when the naming is meaningful).
+2. `exit` and `cycle` may be used with tags, which allows for a very fine-grained control of the loops.
+
+__Example__ tagged nested loops
+
+```fortran
+  integer :: i,j
+  outer_loop: do i=1,10
+    inner_loop: do j=1,10
+      if((j+i) .gt. 10) then ! Print only pairs of i and j that add up to 10
+	    cycle outer_loop     ! Go to the next iteration of the outer loop
+	  end if
+	  print *, 'I=', i, ' J=', j, ' Sum=', j+i
+    end do inner_loop
+  end do outer_loop
 ```

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -169,8 +169,8 @@ __Example__ loop with `cycle`
   integer :: i
   do i=1,10
     if (mod(i,2) == 0) then
-	  cycle ! Don't print even numbers
-	end if
+       cycle  ! Don't print even numbers
+    end if
     print *, i
   end do
 ```
@@ -188,10 +188,10 @@ __Example__ tagged nested loops
   integer :: i,j
   outer_loop: do i=1,10
     inner_loop: do j=1,10
-      if((j+i) > 10) then ! Print only pairs of i and j that add up to 10
-	  cycle outer_loop     ! Go to the next iteration of the outer loop
-	end if
-	print *, 'I=', i, ' J=', j, ' Sum=', j+i
+      if ((j+i) > 10) then  ! Print only pairs of i and j that add up to 10
+         cycle outer_loop  ! Go to the next iteration of the outer loop
+      end if
+      print *, 'I=', i, ' J=', j, ' Sum=', j+i
     end do inner_loop
   end do outer_loop
 ```

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -205,7 +205,7 @@ These requirements place restrictions on what can be placed within the loop body
 
 {% include important.html content="`do concurrent` is not a basic feature of Fortran. The explanation given does not detail
 all the requirements that need to be met in order to write a correct `do concurrent` loop. Compilers are also free to do as they see fit,
-which means they may not optimize the loop."}
+which means they may not optimize the loop." %}
 
 __Example__ `do concurrent()` loop
 

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -124,7 +124,7 @@ __Example:__ `do` loop with skip
   end do
 ```
 
-### `do while()`
+### Conditional loop (`do while`)
 
 A condition may be added to a `do` loop with the `while` keyword. The loop will be executed while the condition given
 in `while()` evaluates to `.true.`.

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -165,7 +165,7 @@ __Example__ `do concurrent()` loop
   print *, result_sin
 ```
 
-### Finer loop control: (`exit`) and (`cycle`)
+### Loop control statements (`exit` and `cycle`)
 
 Most often than not, loops need to be stopped if a condition is met. Fortran presents two reserved words to deal
 with such cases.

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -141,7 +141,7 @@ __Example:__ `do while()` loop
   ! Here i = 11
 ```
 
-### `do concurrent()`
+### Parallelizable loop (`do concurrent`)
 
 The `do concurrent` loop is used to explicitly specify that the _inside of the loop has no interdependencies_; this informs the compiler that it may use parallelization/_SIMD_ to speed-up execution of the loop and conveys programmer intention more clearly. More specifically, this means
 that any loop iteration does not depend on the prior execution of other loop iterations. It is also necessary that any state changes that may occur must only happen within each `do concurrent` loop. 

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -198,7 +198,9 @@ __Example__ loop with `cycle`
     print *, i
   end do
 ```
-### Even finer loop control: tags
+{% include note.html content="When used within nested loops, the `cycle` and `exit` statements operate on the inner-most loop."}
+
+### Nested loop control: tags
 
 A recurring case in any programming language is the use of nested loops. Nested loops refer to loops that exist within another loop. Fortran allows the programmer to _tag_ or _name_ each loop. If loops are tagged, there are two potential benefits:
 1. The readability of the code may be improved (when the naming is meaningful).

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -134,7 +134,7 @@ __Example:__ `do while()` loop
 ```fortran
   integer :: i
   i = 1
-  do while (i<11)
+  do while (i < 11)
     print *, i
     i = i + 1
   end do
@@ -153,7 +153,7 @@ __Example__ loop with `exit`
 ```fortran
   integer :: i
   do i=1, 100
-    if (i .gt. 10) then
+    if (i > 10) then
       exit ! Stop printing numbers
     end if
     print *, i
@@ -168,7 +168,7 @@ __Example__ loop with `cycle`
 ```fortran
   integer :: i
   do i=1,10
-    if (mod(i,2) .eq. 0) then
+    if (mod(i,2) == 0) then
 	  cycle ! Don't print even numbers
 	end if
     print *, i
@@ -188,7 +188,7 @@ __Example__ tagged nested loops
   integer :: i,j
   outer_loop: do i=1,10
     inner_loop: do j=1,10
-      if((j+i) .gt. 10) then ! Print only pairs of i and j that add up to 10
+      if((j+i) > 10) then ! Print only pairs of i and j that add up to 10
 	  cycle outer_loop     ! Go to the next iteration of the outer loop
 	end if
 	print *, 'I=', i, ' J=', j, ' Sum=', j+i

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -141,30 +141,6 @@ __Example:__ `do while()` loop
   ! Here i = 11
 ```
 
-### Parallelizable loop (`do concurrent`)
-
-The `do concurrent` loop is used to explicitly specify that the _inside of the loop has no interdependencies_; this informs the compiler that it may use parallelization/_SIMD_ to speed-up execution of the loop and conveys programmer intention more clearly. More specifically, this means
-that any loop iteration does not depend on the prior execution of other loop iterations. It is also necessary that any state changes that may occur must only happen within each `do concurrent` loop. 
-These requirements place restrictions on what can be placed within the loop body.
-
-
-{% include important.html content="`do concurrent` is not a basic feature of Fortran. The explanation given does not detail
-all the requirements that need to be met in order to write a correct `do concurrent` loop. Compilers are also free to do as they see fit,
-which means they may not optimize the loop."}
-
-__Example__ `do concurrent()` loop
-
-```fortran
-  real, parameter :: pi = 3.14159265
-  integer, parameter :: n = 10
-  real :: result_sin(n)
-  integer :: i
-  do concurrent (i=1:n) ! Careful, the syntax is slightly different
-    result_sin(i) = sin(i*pi/4.)
-  end do
-  print *, result_sin
-```
-
 ### Loop control statements (`exit` and `cycle`)
 
 Most often than not, loops need to be stopped if a condition is met. Fortran provides two executable statements to deal
@@ -218,4 +194,28 @@ __Example__ tagged nested loops
 	print *, 'I=', i, ' J=', j, ' Sum=', j+i
     end do inner_loop
   end do outer_loop
+```
+
+### Parallelizable loop (`do concurrent`)
+
+The `do concurrent` loop is used to explicitly specify that the _inside of the loop has no interdependencies_; this informs the compiler that it may use parallelization/_SIMD_ to speed-up execution of the loop and conveys programmer intention more clearly. More specifically, this means
+that any loop iteration does not depend on the prior execution of other loop iterations. It is also necessary that any state changes that may occur must only happen within each `do concurrent` loop.
+These requirements place restrictions on what can be placed within the loop body.
+
+
+{% include important.html content="`do concurrent` is not a basic feature of Fortran. The explanation given does not detail
+all the requirements that need to be met in order to write a correct `do concurrent` loop. Compilers are also free to do as they see fit,
+which means they may not optimize the loop."}
+
+__Example__ `do concurrent()` loop
+
+```fortran
+  real, parameter :: pi = 3.14159265
+  integer, parameter :: n = 10
+  real :: result_sin(n)
+  integer :: i
+  do concurrent (i=1:n) ! Careful, the syntax is slightly different
+    result_sin(i) = sin(i*pi/4.)
+  end do
+  print *, result_sin
 ```

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -213,9 +213,9 @@ __Example__ tagged nested loops
   outer_loop: do i=1,10
     inner_loop: do j=1,10
       if((j+i) .gt. 10) then ! Print only pairs of i and j that add up to 10
-	    cycle outer_loop     ! Go to the next iteration of the outer loop
-	  end if
-	  print *, 'I=', i, ' J=', j, ' Sum=', j+i
+	  cycle outer_loop     ! Go to the next iteration of the outer loop
+	end if
+	print *, 'I=', i, ' J=', j, ' Sum=', j+i
     end do inner_loop
   end do outer_loop
 ```

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -167,7 +167,7 @@ __Example__ `do concurrent()` loop
 
 ### Loop control statements (`exit` and `cycle`)
 
-Most often than not, loops need to be stopped if a condition is met. Fortran presents two reserved words to deal
+Most often than not, loops need to be stopped if a condition is met. Fortran provides two executable statements to deal
 with such cases.
 
 `exit` is used to quit the loop prematurely. It is usually enclosed inside an `if`.

--- a/learn/quickstart/operators_control_flow.md
+++ b/learn/quickstart/operators_control_flow.md
@@ -143,9 +143,9 @@ __Example:__ `do while()` loop
 
 ### `do concurrent()`
 
-The `do concurrent` loop is used to specify that the _inside of the loop has no interdependencies_. By this, it is indicated
-that any loop does not depend on the loops before it. It is also necessary that any state changes that may occur must only
-happen within each `do concurrent` loop. Because of these requirements, it is important to be carful with what is written inside the loop.
+The `do concurrent` loop is used to explicitly specify that the _inside of the loop has no interdependencies_; this informs the compiler that it may use parallelization/_SIMD_ to speed-up execution of the loop and conveys programmer intention more clearly. More specifically, this means
+that any loop iteration does not depend on the prior execution of other loop iterations. It is also necessary that any state changes that may occur must only happen within each `do concurrent` loop. 
+These requirements place restrictions on what can be placed within the loop body.
 
 However, the true nature of the `do concurrent` construct may not be fully understood by the paragraph above. `do concurrent`
 was specifically created to tell the compiler that it may parallelize/_SIMD_ what is inside the `do concurrent`,


### PR DESCRIPTION
This is a minor expansion of the tutorial page on control flow.

I am not entirely happy with the current result, but I cannot figure out why (probably because it is very short when compared to the rest of the file). So any comments on these changes are welcome.

I expect to continue expanding this with `do concurrent` and tags. However, some initial feedback will be beneficial.

This pull is related to the discussion in #82.

Regards,

Fernando