### PR TITLE
Adding WHIZARD as a Fortran project.

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -696,6 +696,14 @@
   license: GNU GPL V2
   version: 12778
 
+- name: WHIZARD
+  url: https://whizard.hepforge.org/
+  description: Particle Physics Monte Carlo Event Generator
+  categories: scientific
+  tags: particle physics parallel mpi monte carlo optimization sampling integration
+  license: GNU GPL V2
+  version: 2.8.4
+
 # --- Examples / demos / templates ---
 
 - name: Fortran 2018 examples


### PR DESCRIPTION
Proposal to add WHIZARD as a Fortran project. We are a High Energy Physics Monte Carlo Event Generator, so a scientific code, predominantly in Fortran up to F03 and F08 standard. The project ships with a code generator that is written in OCaml and generates Fortran code compiled and linked as shared libraries. Our development is done in a (non-openly visible) gitlab server at the University of Siegen, whose reviewed merge requests are mirrored to our public gitlab server in Siegen and an svn repository at Hepforge. Distribution tarballs are also available via http://launchpad.net/whizard. We are using both OpenMP and MPI for parallelized Monte Carlo integration and simulation, in our development version using also non-blocking communication. Two of our team members, Wolfgang Kilian and Jürgen Reuter, are relatively active on c.l.f., the Intel forum, and the gfortran bugzilla. 