### PR TITLE
Add: license info to Futility package entry.

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -88,6 +88,7 @@
   description: Fortran utilities including unit test harness, arbitrary length strings, parameter list objects, timers, geometry definitions, file wrappers, linear algebra tools, and parallel computing support
   categories: libraries interfaces programming strings io numerical scientific
   version: none
+  license: "Apache v2.0"
 
 # --- Interfaces ---
 


### PR DESCRIPTION
License info is not detected automatically for this package, so add explicitly.