### PR TITLE
package_index: FortranCallGraph and Serialbox

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -188,6 +188,13 @@
   tags: unit testing
   license: BSD 2-clause
 
+- name: FortranCallGraph
+  github: fortesg/fortrancallgraph
+  description: Static source code analysis tool for Fortran
+  categories: programming
+  tags:
+  license: GNU GPL v3
+
 # --- Data types ---
 
 - name: Fortran template library

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -393,6 +393,12 @@
   tags: 
   license: MIT
 
+- name: Serialbox
+  github: GridTools/serialbox
+  description: A serialization library and tools for C/C++, Python3 and Fortran
+  categories: io
+  tags: validation
+  license: "BSD 2 Clause"
 
 # --- Graphics ---
 


### PR DESCRIPTION
While looking for a callgraph generator I stumbled over the FortranCallGraph project (a static callgrapher), from there you can find the FortranTestGenerator (unittest framework based on Capture & Replay via Serialbox), and the serialization library Serialbox (from Swiss Meteo).
The FortranTestGenerator I'm not yet adding due to lack of documentation example code.