### PR TITLE
fix typos in the netcdf-fortran entry

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -310,9 +310,9 @@
   license: none
   version: none
 
-- name: netCFD-Fortran
+- name: netCDF-Fortran
   github: Unidata/netcdf-fortran
-  description: Fortran interfaces for netCFD C library.
+  description: Fortran interfaces for netCDF C library.
   categories: io
   tags: netcdf
   license: none


### PR DESCRIPTION
Fixes a 2 typos in the netcdf-fortran package index entry.