### PR TITLE
Make the link clickable

### DIFF
--- a/_posts/2020-08-01-Fortran-Newsletter-August-2020.md
+++ b/_posts/2020-08-01-Fortran-Newsletter-August-2020.md
@@ -119,7 +119,7 @@ Valentin Clement has been committing initial changes for OpenACC support.
 
 What's new in LFortran:
 
-* The initial prototype C++ backend can translate Fortran's `do concurrent` to C++'s `Kokkos::parallel_for`: https://twitter.com/lfortranorg/status/1280764915242811393
+* The initial prototype C++ backend can translate Fortran's `do concurrent` to C++'s `Kokkos::parallel_for`: [https://twitter.com/lfortranorg/status/1280764915242811393](https://twitter.com/lfortranorg/status/1280764915242811393)
 * LFortran has a Twitter account for latest updates: [@lfortranorg](https://twitter.com/lfortranorg)
 * Work is progressing on the production version of LFortran that is written in C++
 * 22 Merge Requests were merged and 4 issues fixed in July 2020. Some notable ones:


### PR DESCRIPTION
I didn't notice it as part of #125, as it shows fine on GitHub, but the Jekyll Markdown formatting doesn't make the url automatically a link.