### PR TITLE
List FPM registry packages

### DIFF
--- a/.github/workflows/buildPRPreview.yml
+++ b/.github/workflows/buildPRPreview.yml
@@ -57,6 +57,13 @@ jobs:
         sed -i '/baseurl:/d' _config.yml
         echo "baseurl: $(cat base_url)/${{env.BUILD_DIR}}" >> _config.yml
         echo "pull_request: ${{github.event.issue.number}}" >> _config.yml
+    
+    # Download latest fpm-registry index
+    - name: Download fpm-registry index
+      run: |
+        cd ${{env.SRC_DIR}}/_data
+        wget ${{env.FPM_INDEX}}
+        mv index.json fpm_registry_index.json
 
     # Run Jekyll build and copy output to PUBLISH_DIR
     - name: Build Jekyll Site

--- a/.github/workflows/buildPRPreview.yml
+++ b/.github/workflows/buildPRPreview.yml
@@ -14,6 +14,7 @@ env:
   SRC_DIR: src
   PUBLISH_DIR: gh-pages
   SITE_URL: https://fortran-lang.org
+  FPM_INDEX: "https://raw.githubusercontent.com/fortran-lang/fpm-registry/master/index.json"
 
 jobs:
   build:

--- a/.github/workflows/buildSite.yml
+++ b/.github/workflows/buildSite.yml
@@ -12,6 +12,7 @@ on:
 env:
   SRC_DIR: src
   PUBLISH_DIR: gh-pages
+  FPM_INDEX: "https://raw.githubusercontent.com/fortran-lang/fpm-registry/master/index.json"
 
 jobs:
   build:
@@ -48,6 +49,13 @@ jobs:
         cp -r _site/* ../${{env.PUBLISH_DIR}}/
         touch ../${{env.PUBLISH_DIR}}/.nojekyll
     
+    # Download latest fpm-registry index
+    - name: Download fpm-registry index
+      run: |
+        cd _data
+        wget ${{env.FPM_INDEX}}
+        mv index.json fpm_registry_index.json
+
     # Commit and push changes to remote/gh-pages
     - name: Commit and push to gh-pages
       uses: EndBug/add-and-commit@master

--- a/.github/workflows/buildSite.yml
+++ b/.github/workflows/buildSite.yml
@@ -40,7 +40,14 @@ jobs:
         sudo gem install bundler
         bundle config path .bundle
         bundle install
-      
+    
+    # Download latest fpm-registry index
+    - name: Download fpm-registry index
+      run: |
+        cd ${{env.SRC_DIR}}/_data
+        wget ${{env.FPM_INDEX}}
+        mv index.json fpm_registry_index.json
+
     # Run Jekyll build and copy output to PUBLISH_DIR
     - name: Build Jekyll Site
       run: |
@@ -48,13 +55,6 @@ jobs:
         bundle exec jekyll build 
         cp -r _site/* ../${{env.PUBLISH_DIR}}/
         touch ../${{env.PUBLISH_DIR}}/.nojekyll
-    
-    # Download latest fpm-registry index
-    - name: Download fpm-registry index
-      run: |
-        cd _data
-        wget ${{env.FPM_INDEX}}
-        mv index.json fpm_registry_index.json
 
     # Commit and push changes to remote/gh-pages
     - name: Commit and push to gh-pages

--- a/assets/js/package_search.js
+++ b/assets/js/package_search.js
@@ -121,12 +121,14 @@
         
                 project = results[i];
         
-                if (results[i].github != ""){
+                if (results[i].github != "" && !project.fpm){
                     out += '<h3><a href="https://github.com/'+project.github+'" target="_blank">';
                     out += '<i class="devicon-github-plain colored"></i> '+project.name+'</a></h3>';
                 } else {
                     out += '<h3><a href="'+project.url+'" target="_blank">';
-                    if (project.url.includes('gitlab.com')) {
+                    if (project.fpm){
+                        out += '<i class="fas fa-cubes"></i> ';
+                    } else if (project.url.includes('gitlab.com')) {
                         out += '<i class="devicon-gitlab-plain colored"></i> ';
                     } else if (project.url.includes('bitbucket.org')){
                         out += '<i class="devicon-bitbucket-plain colored"></i> ';

--- a/packages/category/fpm.html
+++ b/packages/category/fpm.html
@@ -1,0 +1,87 @@
+---
+layout: default
+title: FPM Registry Packages
+description: Packages listed in the fpm-registry
+permalink: /packages/fpm
+code_category: fpm
+feather-icon: package
+---
+
+
+{% include nav.html active='Packages' %}
+
+<section class="masthead">
+    <h1>FPM Registry</h1>
+    <h3>Projects compatible with the
+        <a href="https://github.com/fortran-lang/fpm" target="_blank">
+            Fortran Package Manager</a>
+    </h3>
+  </section>
+  
+  <section class="front-section">
+    <div class="container">
+      <div class="col-wide">
+        
+        <a href="{{site.baseurl}}/packages">
+            <i class="fas fa-arrow-circle-left"></i>
+            Back to all Packages
+          </a>
+  
+          <table class="projects-table">
+         
+          {% for pkg in site.data.fpm_registry_index.packages %}
+
+          {% for vers in pkg[1] %}
+            {% if vers[0] == 'latest' %}
+              <tr>
+
+                <td> <h3><a href="{{ vers[1].git }}" target="_blank">
+                    <i class="fas fa-cubes"></i>
+                    {{ vers[1].name }}</a></h3> </td>
+                
+                <td>
+                    <img src="https://img.shields.io/badge/Version-{{ vers[1].version | replace: " ", "%20" | replace: "-", "--" }}-green.svg">
+                </td>
+
+                <td>
+                    <img src="https://img.shields.io/badge/License-{{ vers[1].license | replace: " ", "%20" | replace: "-", "--" }}-green">
+                </td>
+
+              </tr>
+
+              <tr><td colspan="3" class="light small">
+                <b>Author: </b>  {{ vers[1].author }} &nbsp &nbsp
+                <b>Maintainer: </b>  {{ vers[1].maintainer }}
+              </td></tr>
+              {% if vers[1].description %}
+              <tr><td colspan="3" class="light small">
+                {{ vers[1].description }}
+              </td></tr>
+              {% endif %}
+              <tr><td colspan="3"></td></tr>
+              
+            {% endif %}
+          {% endfor %} 
+
+          {% endfor %} 
+          
+          </table>        
+         
+      </div>
+  
+    </div>
+  </section>
+  
+  <section class="front-section shaded">
+    <div class="container">
+      <div class="col-wide">
+        <!-- <h2 id="faqs">FAQ</h2> -->
+        
+        See
+	  <a href="https://github.com/fortran-lang/fpm-registry" target="_blank">
+      <i class="devicon-github-plain colored"></i> here</a> to find out more about the fpm registry
+        and how you can get your fpm compatible package listed.
+  
+    </div>
+  </section>
+  

--- a/packages/index.html
+++ b/packages/index.html
@@ -71,7 +71,11 @@ description: A rich ecosystem of high-performance code
             {% endif %}
           <a href="{{ site.baseurl }}{{ sitePage.url }}" >
             {{ sitePage.title }}
-            {% assign catProjects =  site.data.package_index | where_exp:"project", "project.categories contains sitePage.code_category"%}
+            {% if sitePage.code_category == 'fpm' %}
+              {% assign catProjects =  site.data.fpm_registry_index.packages %}
+            {% else %}
+              {% assign catProjects =  site.data.package_index | where_exp:"project", "project.categories contains sitePage.code_category"%}
+            {% endif %}
             ({{ catProjects | size }})
           </a></h3>
           <p> {{ sitePage.description }} </p>

--- a/packages/package_index.json
+++ b/packages/package_index.json
@@ -11,8 +11,27 @@ layout: null
           "url": "{{ project.url }}",
           "categories": "{{ project.categories }}",
           "tags": "{{ project.tags }}",
-          "license": "{{ project.license }}"
+          "license": "{{ project.license }}",
+          "fpm": false
         }
+        {% unless forloop.last %},{% endunless %}
+      {% endfor %}
+      ,
+      {% for pkg in site.data.fpm_registry_index.packages %}
+        {% for pkg_ver in pkg[1] %}
+          {% if pkg_ver[0] == 'latest' %}
+            {
+              "name": "{{ pkg_ver[1].name }}",
+              "description": "{{ pkg_ver[1].description }}",
+              "github": "",
+              "url": "{{ pkg_ver[1].git }}",
+              "categories": "fpm",
+              "tags": "fpm",
+              "license": "{{ pkg_ver[1].license }}",
+              "fpm": true
+            }
+          {% endif %}
+        {% endfor %}
         {% unless forloop.last %},{% endunless %}
       {% endfor %}
     ]


### PR DESCRIPTION
A minimal modification to include packages from fpm-registry on the website.
They are listed in their own category ('fpm') as well as searchable via the existing search function.

This is a stopgap until we can clean this up and separate out fpm-registry like crates.io to provide more info.