### PR TITLE
Small fix in the opening sentence on the compilers page

### DIFF
--- a/compilers.md
+++ b/compilers.md
@@ -4,7 +4,7 @@ title: Fortran Compilers
 navbar: Compilers
 ---
 
-Fortran has several open source and commercial compilers.
+Fortran has over a dozen open source and commercial compilers.
 
 ## Open source compilers
 


### PR DESCRIPTION
We list a total of 16 compilers on the page, so the opening line should be fixed.