### PR TITLE
Revert "Improved Docs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the source for the fortran-lang.io website. 
 It's derived from https://github.com/neovim/neovim.github.io.
 
-## Contributing:
+## Contributing
 
 * [CONTRIBUTING](./CONTRIBUTING.md): getting started and general guidance on contributing to <https://fortran-lang.org>
 
@@ -11,7 +11,7 @@ It's derived from https://github.com/neovim/neovim.github.io.
 
 * [PACKAGES](./PACKAGES.md): adding an entry to the [Package index](https://fortran-lang.org/packages)
 
-## How To Setup:
+## Setup
 
 This assumes that you already have a recent Ruby with RubyGems.
 


### PR DESCRIPTION
I'm sorry, I don't think this PR improves the README, but opposite:

* Headings shouldn't end with colons
* "How to setup" doesn't work because "setup" is a noun. We can work to change it something like "How to set up Jekyll"

Reverts fortran-lang/fortran-lang.org#139