### PR TITLE
Add DFTB+ to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -593,6 +593,13 @@
 
 # --- Scientific codes ---
 
+- name: "DFTB+"
+  github: dftbplus/dftbplus
+  description: "DFTB+ general package for performing fast atomistic simulations"
+  categories: scientific
+  license: LGPL-3.0-or-later
+  tags: tight-binding quantum-mechanics density-functional-theory
+
 - name: WRF
   github: wrf-model/WRF
   description: Weather Research and Forecasting model


### PR DESCRIPTION
Disclaimer: *this is a project I'm personally involved with.*

This PR adds an entry for DFTB+

- GH organisation of the project: https://github.com/dftbplus
- Project homepage: https://dftbplus.org/
- the projects builds with CMake
- supports GCC7.5, GCC8.4, GCC9.2, GCC10.1, Intel 18, Intel 19, NAG 7
- MPI and/or OpenMP parallel
- documentation for DFTB+
  - developer docs: https://dftbplus-develguide.readthedocs.io/en/latest/
  - user docs: https://dftbplus-recipes.readthedocs.io/en/latest/

See #68