### PR TITLE
Add fypp to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -157,7 +157,13 @@
   description: Automatic documentation generator for modern Fortran programs
   categories: programming preview
   tags: documentation
-  
+
+- name: fypp
+  github: aradi/fypp
+  description: Python powered Fortran preprocessor
+  categories: programming
+  license: BSD-2-Clause
+  tags: metaprogramming
 
 - name: vegetables
   url: https://gitlab.com/everythingfunctional/vegetables


### PR DESCRIPTION
I wonder why this one is missing here

- GH repository: https://github.com/aradi/fypp
- documentation: https://fypp.readthedocs.io