### PR TITLE
Correct license identifiers

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -4,16 +4,16 @@
 #  'description' (mandatory) single line description
 #  'categories'  (mandatory)
 #  'tags'        (optional) used for searching. Don't include category name here.
-#  'license'     (optional) override automatic github license. Set to 'none' to hide.
+#  'license'     (optional) override automatic github license. Mandatory if automatic detection fails.
 #  'version'     (optional) override automatic github version. Set to 'none' to hide.
 #
 # Fields for non github projects:
 #  'name'        (mandatory)
 #  'url'         (mandatory)
+#  'license'     (mandatory)
 #  'description' (mandatory) single line description
 #  'categories'  (mandatory)
 #  'tags'        (optional) used for searching. Don't include category name here.
-#  'license'     (optional)
 #  'version'     (optional)
 #
 # Browsable category names (lowercase!):

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -55,7 +55,7 @@
   description: Fortran command Line Arguments Parser
   categories: libraries
   tags: command line cli argument parser
-  license: none
+  license: GPL-3.0
 
 - name: Fortran Standard Library (stdlib)
   github: fortran-lang/stdlib
@@ -140,7 +140,7 @@
   description: File system manipulation and unit testing framework
   categories: interfaces programming
   tags: posix libc
-  license: BSD 2-clause
+  license: BSD-2-clause
 
 - name: sqliteff
   url: https://gitlab.com/everythingfunctional/sqliteff
@@ -172,28 +172,28 @@
   description: Parallel Fortran Unit Testing Framework
   categories: programming
   tags: unit testing
-  license: none
+  license: NASA-1.3
 
 - name: erloff
   url: https://gitlab.com/everythingfunctional/erloff
   description: Errors and logging for fortran
   categories: programming
   tags: errors logging
-  license: "BSD 3-Clause"
+  license: BSD-3-Clause
 
 - name: fytest
   url: https://bitbucket.org/aradi/fytest/src/develop/
   description: a lightweight unit testing framework for Fortran
   categories: programming
   tags: unit testing
-  license: BSD 2-clause
+  license: BSD-2-clause
 
 - name: FortranCallGraph
   github: fortesg/fortrancallgraph
   description: Static source code analysis tool for Fortran
   categories: programming
   tags:
-  license: GNU GPL v3
+  license: GPL-3.0
 
 # --- Data types ---
 
@@ -203,14 +203,14 @@
   categories: data-types 
   tags: resizeable array container linked list hash map regex string shared pointer
   version: none
-  license: GNU GPL v3
+  license: LGPL-3.0-or-later
 
 - name: PENF
   github: szaghi/PENF
   description: Provides portable kind-parameters and many useful procedures to deal with them
   categories: data-types numerical
   tags: kinds integer real ieee floating point floats precision
-  license: none
+  license: GPL-3.0
 
 - name: M_time
   github: urbanjost/M_time
@@ -230,14 +230,14 @@
   description: A kd-tree implementation in fortran
   categories: data-types
   version: none
-  license: none
+  license: AFL-1.1
 
 - name: datetime-fortran
   github: wavebitscientific/datetime-fortran
   description: Date and time manipulation 
   categories: data-types
   tags: day year month calendar weekday clock
-  license: none
+  license: MIT
   version: none
 
 - name: qContainers
@@ -245,7 +245,7 @@
   description: Store any intrinsic or derived data type to a container
   categories: data-types
   tags: qlibc tree table hash table linked list vector dynamic array unique set
-  license: none
+  license: BSD-2-Clause
   version: none
 
 - name: Lookup Table Fortran
@@ -260,7 +260,7 @@
   description: generic collection templates for Fortran
   categories: data-types
   tags: 
-  license: BSD 2-Clause
+  license: BSD-2-Clause
 
 
 # --- Strings ---
@@ -270,7 +270,7 @@
   description: Fortran strings manipulator
   categories: strings
   tags: split join basename search concat
-  license: none
+  license: GPL-3.0
 
 - name: M_strings
   github: urbanjost/M_strings
@@ -300,14 +300,14 @@
   description: A Fortran 2008 JSON API
   categories: io
   tags: json io
-  license: none
+  license: BSD-3-Clause
 
 - name: VTKFortran
   github: szaghi/VTKFortran
   description: Library to parse and emit files conforming VTK (XML) standard
   categories: io
   tags: 
-  license: none
+  license: GPL-3.0
   version: none
 
 - name: netCDF-Fortran
@@ -315,14 +315,14 @@
   description: Fortran interfaces for netCDF C library.
   categories: io
   tags: netcdf
-  license: none
+  license: BSD-3-Clause AND Apache-2.0
 
 - name: fox
   github: andreww/fox
   description: A Fortran XML library
   categories: io
   tags: 
-  license: none
+  license: BSD-3-Clause
   version: none
 
 - name: FEconv
@@ -349,14 +349,14 @@
   description: Read and write CSV Files using modern Fortran
   categories: io
   tags: 
-  license: none
+  license: BSD-3-Clause
 
 - name: M_IO
   github: urbanjost/M_io
   description: Fortran module for common I/O tasks
   categories: io
   tags: delete slurp swallow dirname split path 
-  license: Public domain
+  license: Unlicense
   version: none
 
 - name: jsonff
@@ -377,7 +377,7 @@
   description: INI ParseR and generator
   categories: io 
   tags: config
-  license: none
+  license: GPL-3.0-only
 
 - name: config_fortran
   github: jannisteunissen/config_fortran
@@ -398,7 +398,7 @@
   description: A serialization library and tools for C/C++, Python3 and Fortran
   categories: io
   tags: validation
-  license: "BSD 2 Clause"
+  license: BSD-2-Clause
 
 # --- Graphics ---
 
@@ -422,14 +422,14 @@
   description: For generating plots from Fortran using Python's matplotlib.pyplot
   categories: graphics interfaces
   tags: pyplot matplotlib contour histogram
-  license: none
+  license: BSD-3-Clause
 
 - name: ogpf
   github: kookma/ogpf
   description: Object based interface to GnuPlot for Fortran
   categories: graphics interfaces
   tags: animation plot surface contour 
-  license: none
+  license: MIT
   version: none
 
 - name: gtk-fortran
@@ -472,7 +472,7 @@
   description: Routines for numerical linear algebra
   categories: numerical
   tags: blas linear algera
-  license: BSD 3-Clause
+  license: BSD-3-Clause
 
 - name: ElmerFEM
   github: ElmerCSC/elmerfem
@@ -499,7 +499,7 @@
   description: Collection of Fortran77 subroutines designed to solve large scale eigenvalue problems.
   categories: numerical
   tags: eigenvalue eigenvector singular value decomposition svd
-  license: BSD 3-Clause
+  license: BSD-3-Clause
 
 - name: neural-fortran
   github: modern-fortran/neural-fortran
@@ -520,14 +520,14 @@
   description: Multidimensional B-Spline interpolation of data on a regular grid
   categories: numerical
   tags: spline interpolation extrapolation integration integral
-  license: none
+  license: BSD-3-Clause
 
 - name: FOODIE
   github: Fortran-FOSS-Programmers/FOODIE
   description: Fortran Object-Oriented Differential-equations Integration Environment
   categories: numerical
   tags: ode pde euler runge kutta
-  license: none
+  license: GPL-3.0-only
 
 - name: fgsl
   github: reinh-bader/fgsl
@@ -567,14 +567,14 @@
   description: SLSQP nonlinear constrained optimizer
   categories: numerical
   tags: nonlinear programming equality inequality constraints 
-  license: none
+  license: BSD-3-Clause AND MIT
 
 - name: NumDiff
   github: jacobwilliams/NumDiff
   description: a modern Fortran interface for computing the Jacobian (derivative) matrix of m nonlinear functions which depend on n variables
   categories: numerical
   tags: finite difference
-  license: none
+  license: BSD-3-Clause
 
 - name: quaff
   url: https://gitlab.com/everythingfunctional/quaff
@@ -603,7 +603,7 @@
   github: firemodels/fds
   description: Large-eddy simulation code for low-speed flows, with an emphasis on smoke and heat transport from fires.
   categories: scientific
-  license: none
+  license: NIST-PD-fallback
 
 - name: Quantum ESPRESSO
   github: QEF/q-e
@@ -626,7 +626,7 @@
   description: MPI parallel higher-order spectral element CFD solver
   categories: scientific
   tags: cfd computational fluid dynamics spectral element higher order mpi parallel les rans
-  license: none
+  license: BSD-3-Clause
 
 - name: cp2k
   github: cp2k/cp2k
@@ -640,7 +640,7 @@
   description: An adaptive mesh, astrophysical radiation hydrodynamics simulation code
   categories: scientific
   tags: adaptive mesh astrophysics radiation hydrodynamics
-  license: BSD 3-Clause
+  license: BSD-3-Clause
 
 - name: QUIP
   github: libAtoms/QUIP
@@ -660,7 +660,7 @@
   description: NASA Structural Analysis System, a finite element analysis program (FEA) completed in the early 1970's 
   categories: scientific
   tags: finite element structural eigne stability loads
-  license: none
+  license: NASA-1.3
   version: none
 
 - name: "OFF"
@@ -676,7 +676,7 @@
   description: A three-dimensional unstructured finite volume code for fluid flow simulations.
   categories: scientific
   tags: finite volume turbulent turbulence
-  license: GNU GPL v3
+  license: GPL-3.0
   version: none
 
 - name: CaNS
@@ -691,14 +691,14 @@
   description: A finite volume RANS solver tailored for gradient-based aerodynamic design optimization
   categories: scientific
   tags: simulation computational fluid dynamics automatic differentiation adjoint structured multiblock overset python hpc cfd mpi
-  license: LGPL v2
+  license: LGPL-2.1-only
 
 - name: Truchas
   url: https://gitlab.com/truchas/truchas
   description: 3D Multiphysics Simulation of Metal Casting and Processing
   categories: scientific
   tags: fluid dynamics metal casting multiphysics hpc
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   version: none
 
 - name: dftatom
@@ -722,7 +722,7 @@
   description: Particle Physics Monte Carlo Event Generator
   categories: scientific
   tags: particle physics parallel mpi monte carlo optimization sampling integration
-  license: GNU GPL V2
+  license: GPL-2.0-or-later
   version: 2.8.4
 
 # --- Examples / demos / templates ---

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -97,7 +97,7 @@
   description: allows you to use Python features in Fortran 
   categories: interfaces
   tags: dict list tuple numpy python matplotlib scipy
-  license: GNU GPL v3
+  license: GPL-3.0
   version: none
 
 - name: tcp-client-server
@@ -113,7 +113,7 @@
   categories: interfaces
   tags: gpu compute accelerator
   version: none
-  license: GNU GPL v3
+  license: GPL-3.0
 
 - name: M_process
   github: urbanjost/M_process
@@ -377,7 +377,7 @@
   description: INI ParseR and generator
   categories: io 
   tags: config
-  license: GPL-3.0-only
+  license: GPL-3.0
 
 - name: config_fortran
   github: jannisteunissen/config_fortran
@@ -407,14 +407,14 @@
   description: Fortran 2003 interface to OpenGL
   categories: graphics interfaces
   tags: graphics interface opengl
-  license: GNU GPL v3
+  license: GPL-3.0
 
 - name: PLplot
   url: http://plplot.sourceforge.net/
   description: Library for scientific plotting
   categories: graphics interfaces
   tags: plot surface contour interface
-  license: GNU LGPL v3
+  license: LGPL-3.0
   version: 5.15.0
 
 - name: pyplot-fortran
@@ -527,7 +527,7 @@
   description: Fortran Object-Oriented Differential-equations Integration Environment
   categories: numerical
   tags: ode pde euler runge kutta
-  license: GPL-3.0-only
+  license: GPL-3.0
 
 - name: fgsl
   github: reinh-bader/fgsl
@@ -560,7 +560,7 @@
   description: Modules for nonlinear optimization
   categories: numerical
   tags: least squares active set quadratic programming interior point convex programming linear programming
-  license: GNU LGPL v3
+  license: LGPL-3.0
 
 - name: slsqp
   github: jacobwilliams/slsqp
@@ -588,7 +588,7 @@
   description: Pseudo random number generator in Fortran, internally using xoroshiro128+
   categories: numerical
   tags: uniform normal poisson distributed
-  license: GNU GPL v3
+  license: GPL-3.0
   version: none
 
 # --- Scientific codes ---
@@ -633,7 +633,7 @@
   description: quantum chemistry and solid state physics software package that can perform atomistic simulations 
   categories: scientific
   tags: quantum chemistry physics molecular dynamics metadynamics mpi cuda
-  license: GNU GPL V2
+  license: GPL-2.0
 
 - name: Castro
   github: AMReX-Astro/Castro
@@ -647,7 +647,7 @@
   description: The QUIP package is a collection of software tools to carry out molecular dynamics simulations.
   categories: scientific
   tags: electronic structure calculations quantum chemistry physics molecular dynamics mpi qm-mm
-  license: GNU GPL V2
+  license: GPL-2
 
 - name: ABINIT
   github: abinit/abinit
@@ -668,7 +668,7 @@
   description: Finite volume fluid dynamics
   categories: scientific
   tags: godunov riemann euler runge kutta structured
-  license: GNU GPL v3
+  license: GPL-3.0
   version: none
 
 - name: freeCappuccino
@@ -714,7 +714,7 @@
   description: Modules for Experiments in Stellar Astrophysics
   categories: scientific
   tags: stellar astrophysics
-  license: GNU GPL V2
+  license: GPL-2
   version: 12778
 
 - name: WHIZARD
@@ -732,7 +732,7 @@
   description: Easy examples of scientific computing with modern, powerful, easy Fortran 2018 standard
   categories: examples
   tags: block coarray contiguous mpi namelist openmp random submodule iso_fortran_env
-  license: GNU GPL V2
+  license: GPL-2
 
 - name: Fortran patterns
   github: farhanjk/FortranPatterns

--- a/_layouts/code_category.html
+++ b/_layouts/code_category.html
@@ -33,14 +33,14 @@ layout: default
                 {{ project.name }}</a></h3> </td>
               <td> {% if project.version %}
                   {% if project.version != 'none' %}
-                  <img src="https://img.shields.io/badge/Version-{{ project.version | replace: " ", "%20" | replace: "-", "--" }}-green.svg">
+                  <img src="https://img.shields.io/badge/version-{{ project.version | replace: " ", "%20" | replace: "-", "--" }}-green.svg">
                   {% endif%}
                   {% else %}
                   <img src="https://img.shields.io/github/v/release/{{ project.github }}?color=green">
               {% endif %}</td>
               <td> {% if project.license %}
                    {% if project.license != 'none' %}
-                   <img src="https://img.shields.io/badge/License-{{ project.license | replace: " ", "%20" | replace: "-", "--" }}-green">
+                   <img src="https://img.shields.io/badge/license-{{ project.license | replace: " ", "%20" | replace: "-", "--" }}-green">
                    {% endif%}
                    {% else %}
                    <img src="https://img.shields.io/github/license/{{ project.github }}">
@@ -59,11 +59,11 @@ layout: default
                 {% endif %}
                 {{ project.name }}</a></h3> </td>
               <td> {% if project.version %}
-                  <img src="https://img.shields.io/badge/Version-{{ project.version | replace: " ", "%20" | replace: "-", "--" }}-green.svg">
+                  <img src="https://img.shields.io/badge/version-{{ project.version | replace: " ", "%20" | replace: "-", "--" }}-green.svg">
                   {% endif %}
               </td>
               <td> {% if project.license %}
-                  <img src="https://img.shields.io/badge/License-{{ project.license | replace: " ", "%20" | replace: "-", "--" }}-green">
+                  <img src="https://img.shields.io/badge/license-{{ project.license | replace: " ", "%20" | replace: "-", "--" }}-green">
                   {% endif %}
               </td>
               <td></td>

--- a/_layouts/code_category.html
+++ b/_layouts/code_category.html
@@ -32,16 +32,12 @@ layout: default
                 <i class="devicon-github-plain colored"></i>
                 {{ project.name }}</a></h3> </td>
               <td> {% if project.version %}
-                  {% if project.version != 'none' %}
                   <img src="https://img.shields.io/badge/version-{{ project.version | replace: " ", "%20" | replace: "-", "--" }}-green.svg">
-                  {% endif%}
                   {% else %}
                   <img src="https://img.shields.io/github/v/release/{{ project.github }}?color=green">
               {% endif %}</td>
               <td> {% if project.license %}
-                   {% if project.license != 'none' %}
                    <img src="https://img.shields.io/badge/license-{{ project.license | replace: " ", "%20" | replace: "-", "--" }}-green">
-                   {% endif%}
                    {% else %}
                    <img src="https://img.shields.io/github/license/{{ project.github }}">
                {% endif %}</td>


### PR DESCRIPTION
`license: none` should be a no-go for the package index. The package index is of course no legal advice for licensing, but the information should be as accurate as possible. A package without license is unusable by definition (for open source projects), which is unfair to packages with permissive licensing conditions.
For a simple summary see: https://choosealicense.com/no-permission/

I went through all the packages with `license: none` and tried to identify the licenses. I also tried to correct all licenses which are not valid SPDX license identifiers. Many missing licenses were malformatted BSD or MIT licenses, but some had actually interesting licensing condition like original MIT license with changes under BSD-3-Clause and so on.

There are still some issues with the GPL-2.0, and GPL-3.0, which should have the `-only` or `-or-later` suffix. (L)GPL-2 and (L)GPL-3 is usually insufficient to identify the license of a package clearly, since the minor version is missing.

This PR is open for discussion.
