### PR TITLE
add CI for publishing on the fortran-lang twitter account upon merging a certain PR

### DIFF
--- a/.github/workflows/gen_tweet.yaml
+++ b/.github/workflows/gen_tweet.yaml
@@ -1,0 +1,108 @@
+name: twitter bot
+
+# runs on issues that have been created
+on:
+  issue_comment:
+    types: [created]
+
+# setup environment variables
+env:
+  TWEET_KEYWORD: '__[tweet]__'
+  UNTWEET_KEYWORD: '__[untweet]__'
+  UNTWEET_EDIT_COMMENT_KEYWORD: '__[tweet withdrawn]__'
+  ERROR_KEYWORD: '__[error]__'
+  TWEET_MAX_CHAR: 280
+  TWITTER_HANDLE: fortranlang
+  TWITTER_URL: https://twitter.com/fortranlang
+
+jobs:
+  # withdraws the tweet CI comment
+  untweet:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body,'#untweet')
+    steps:
+    - name: find the tweet comment matching the keyword env.TWEET_KEYWORD
+      uses: peter-evans/find-comment@v1
+      id: fc
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        comment-author: github-actions[bot]
+        body-includes: ${{ env.TWEET_KEYWORD }}
+#   - run: echo ${{steps.fc.outputs.comment-id}}
+    - name: if tweet CI comment is found, replace CI comment to undo it
+      if: ${{ steps.fc.outputs.comment-id != null }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{steps.fc.outputs.comment-id}}
+        edit-mode: replace
+        body: |
+          ${{env.UNTWEET_EDIT_COMMENT_KEYWORD}}
+    - name: fetch comment url
+      if: ${{ steps.fc.outputs.comment-id != null }}
+      id: get-comment-url
+      run: |
+        echo ::set-output name=comment-url::$(echo "${{github.event.issue.pull_request.url}}\#issuecomment-${{steps.fc.outputs.comment-id}}" | sed 's/api\.//; s/repos\///; s/pulls/pull/')
+    - name: if tweet CI comment found, report it in a new comment
+      if: ${{ steps.fc.outputs.comment-id != null }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{github.event.issue.number}}
+        body: |
+          ${{env.UNTWEET_KEYWORD}} removed previous tweet [above](${{steps.get-comment-url.outputs.comment-url}}).
+  # writes a tweet CI comment
+  tweet:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body,'#tweet')
+    steps:
+    - name: search for a previous tweet CI comment matching the keyword env.TWEET_KEYWORD
+      uses: peter-evans/find-comment@v1
+      id: fc
+      with:
+        issue-number: ${{github.event.issue.number}}
+        comment-author: github-actions[bot]
+        body-includes: ${{env.TWEET_KEYWORD}}
+#   - run: echo ${{steps.fc.outputs.comment-id}}
+    - name: if tweet CI comment is found, replace CI comment to undo it
+      if: ${{ steps.fc.outputs.comment-id != null }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{steps.fc.outputs.comment-id}}
+        edit-mode: replace
+        body: |
+          ${{env.UNTWEET_EDIT_COMMENT_KEYWORD}}
+#   - name: fetch comment url
+#     if: ${{ steps.fc.outputs.comment-id != null }}
+#     id: get-comment-url
+#     run: |
+#       echo ::set-output name=comment-url::$(echo "${{github.event.issue.pull_request.url}}\#issuecomment-${{steps.fc.outputs.comment-id}}" | sed 's/api\.//; s/repos\///')
+#   - name: if tweet CI comment is found, report it in a new comment
+#     if: ${{ steps.fc.outputs.comment-id != null }}
+#     uses: peter-evans/create-or-update-comment@v1
+#     with:
+#       issue-number: ${{github.event.issue.number}}
+#       body: |
+#         ${{env.UNTWEET_KEYWORD}} removed previous tweet [above](${{steps.get-comment-url.outputs.comment-url}}).
+    - name: extract the new tweet message
+      id: get-comment-body
+      run: |
+        echo '${{github.event.comment.body}}' | sed '1 s/#tweet//' | sed '1 s/ //' > tweet.txt
+        echo ::set-output name=tweet_length::$(cat tweet.txt | tr -d '\n\r%' | wc -c)
+        sed 's/^/> /' tweet.txt > tweet_quote.txt
+        body=$(cat tweet.txt)
+        body="${body//'%'/'%25'}"
+        body="${body//$'\n'/'%0A'}"
+        body="${body//$'\r'/'%0D'}"
+        echo ::set-output name=body::$body
+        body_quote=$(cat tweet_quote.txt)
+        body_quote="${body_quote//'%'/'%25'}"
+        body_quote="${body_quote//$'\n'/'%0A'}"
+        body_quote="${body_quote//$'\r'/'%0D'}"
+        echo ::set-output name=body_quote::$body_quote
+        rm tweet.txt tweet_quote.txt
+    - name: print new tweet CI message in a new comment
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{github.event.issue.number}}
+        body: |
+          ${{env.TWEET_KEYWORD}} the following message will be tweeted in [@${{env.TWITTER_HANDLE}}](${{env.TWITTER_URL}}) after this PR is merged (character count: ${{steps.get-comment-body.outputs.tweet_length}}/${{env.TWEET_MAX_CHAR}}):
+          ${{steps.get-comment-body.outputs.body_quote}}

--- a/.github/workflows/gen_tweet.yaml
+++ b/.github/workflows/gen_tweet.yaml
@@ -25,12 +25,12 @@ jobs:
       uses: peter-evans/find-comment@v1
       id: fc
       with:
-        issue-number: ${{ github.event.issue.number }}
+        issue-number: ${{github.event.issue.number}}
         comment-author: github-actions[bot]
-        body-includes: ${{ env.TWEET_KEYWORD }}
+        body-includes: ${{env.TWEET_KEYWORD}}
 #   - run: echo ${{steps.fc.outputs.comment-id}}
     - name: if tweet CI comment is found, replace CI comment to undo it
-      if: ${{ steps.fc.outputs.comment-id != null }}
+      if: ${{steps.fc.outputs.comment-id != null}}
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{steps.fc.outputs.comment-id}}
@@ -38,12 +38,12 @@ jobs:
         body: |
           ${{env.UNTWEET_EDIT_COMMENT_KEYWORD}}
     - name: fetch comment url
-      if: ${{ steps.fc.outputs.comment-id != null }}
+      if: ${{steps.fc.outputs.comment-id != null}}
       id: get-comment-url
       run: |
         echo ::set-output name=comment-url::$(echo "${{github.event.issue.pull_request.url}}\#issuecomment-${{steps.fc.outputs.comment-id}}" | sed 's/api\.//; s/repos\///; s/pulls/pull/')
     - name: if tweet CI comment found, report it in a new comment
-      if: ${{ steps.fc.outputs.comment-id != null }}
+      if: ${{steps.fc.outputs.comment-id != null}}
       uses: peter-evans/create-or-update-comment@v1
       with:
         issue-number: ${{github.event.issue.number}}
@@ -63,7 +63,7 @@ jobs:
         body-includes: ${{env.TWEET_KEYWORD}}
 #   - run: echo ${{steps.fc.outputs.comment-id}}
     - name: if tweet CI comment is found, replace CI comment to undo it
-      if: ${{ steps.fc.outputs.comment-id != null }}
+      if: ${{steps.fc.outputs.comment-id != null}}
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{steps.fc.outputs.comment-id}}
@@ -71,12 +71,12 @@ jobs:
         body: |
           ${{env.UNTWEET_EDIT_COMMENT_KEYWORD}}
 #   - name: fetch comment url
-#     if: ${{ steps.fc.outputs.comment-id != null }}
+#     if: ${{steps.fc.outputs.comment-id != null}}
 #     id: get-comment-url
 #     run: |
 #       echo ::set-output name=comment-url::$(echo "${{github.event.issue.pull_request.url}}\#issuecomment-${{steps.fc.outputs.comment-id}}" | sed 's/api\.//; s/repos\///')
 #   - name: if tweet CI comment is found, report it in a new comment
-#     if: ${{ steps.fc.outputs.comment-id != null }}
+#     if: ${{steps.fc.outputs.comment-id != null}}
 #     uses: peter-evans/create-or-update-comment@v1
 #     with:
 #       issue-number: ${{github.event.issue.number}}

--- a/.github/workflows/gen_tweet.yaml
+++ b/.github/workflows/gen_tweet.yaml
@@ -8,9 +8,7 @@ on:
 # setup environment variables
 env:
   TWEET_KEYWORD: '__[tweet]__'
-  UNTWEET_KEYWORD: '__[untweet]__'
   UNTWEET_EDIT_COMMENT_KEYWORD: '__[tweet withdrawn]__'
-  ERROR_KEYWORD: '__[error]__'
   TWEET_MAX_CHAR: 280
   TWITTER_HANDLE: fortranlang
   TWITTER_URL: https://twitter.com/fortranlang

--- a/.github/workflows/gen_tweet.yaml
+++ b/.github/workflows/gen_tweet.yaml
@@ -86,6 +86,8 @@ jobs:
         echo "${{github.event.comment.body}}" | sed '1 s/#tweet//' | sed '1 s/ //' > tweet.txt
         echo ::set-output name=tweet_length::$(cat tweet.txt | tr -d '\n\r%' | wc -c)
         sed 's/^/> /' tweet.txt > tweet_quote.txt
+        # escape file content to preserve new lines
+        # (see example in https://github.com/peter-evans/create-or-update-comment)
         body=$(cat tweet.txt)
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"

--- a/.github/workflows/gen_tweet.yaml
+++ b/.github/workflows/gen_tweet.yaml
@@ -85,7 +85,7 @@ jobs:
     - name: extract the new tweet message
       id: get-comment-body
       run: |
-        echo '${{github.event.comment.body}}' | sed '1 s/#tweet//' | sed '1 s/ //' > tweet.txt
+        echo "${{github.event.comment.body}}" | sed '1 s/#tweet//' | sed '1 s/ //' > tweet.txt
         echo ::set-output name=tweet_length::$(cat tweet.txt | tr -d '\n\r%' | wc -c)
         sed 's/^/> /' tweet.txt > tweet_quote.txt
         body=$(cat tweet.txt)

--- a/.github/workflows/gen_tweet.yaml
+++ b/.github/workflows/gen_tweet.yaml
@@ -83,22 +83,19 @@ jobs:
     - name: extract the new tweet message
       id: get-comment-body
       run: |
-        echo "${{github.event.comment.body}}" | sed '1 s/#tweet//' | sed '1 s/ //' > tweet.txt
-        echo ::set-output name=tweet_length::$(cat tweet.txt | tr -d '\n\r%' | wc -c)
-        sed 's/^/> /' tweet.txt > tweet_quote.txt
-        # escape file content to preserve new lines
+        body=$(echo "${{github.event.comment.body}}" | sed '1 s/#tweet//' | sed '1 s/ //')
+        echo ::set-output name=tweet_length::$(echo $body | tr -d '\n\r%' | wc -c)
+        body_quote=$(echo $body | sed 's/^/> /')
+        # escape string content to preserve new lines
         # (see example in https://github.com/peter-evans/create-or-update-comment)
-        body=$(cat tweet.txt)
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"
         body="${body//$'\r'/'%0D'}"
-        echo ::set-output name=body::$body
-        body_quote=$(cat tweet_quote.txt)
         body_quote="${body_quote//'%'/'%25'}"
         body_quote="${body_quote//$'\n'/'%0A'}"
         body_quote="${body_quote//$'\r'/'%0D'}"
+        echo ::set-output name=body::$body
         echo ::set-output name=body_quote::$body_quote
-        rm tweet.txt tweet_quote.txt
     - name: print new tweet CI message in a new comment
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/.github/workflows/send_tweet.yaml
+++ b/.github/workflows/send_tweet.yaml
@@ -1,0 +1,42 @@
+name: send a tweet if PR is merged (and there is a tweet to be sent)
+
+on:
+  pull_request:
+    types: [closed]
+env:
+  TWEET_KEYWORD: '__[tweet]__'
+
+jobs:
+  publish_tweet:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged
+    steps:
+    - name: find the tweet comment matching the keyword env.TWEET_KEYWORD
+      uses: peter-evans/find-comment@v1
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: github-actions[bot]
+        body-includes: ${{env.TWEET_KEYWORD}}
+    - run: |
+        echo ${{ github.event.pull_request.number }} ${{ env.TWEET_KEYWORD }} ${{steps.fc.outputs.comment-id}}
+    - name: if tweet CI comment is found, extract tweet from comment body
+      id: extract-tweet
+      if: ${{steps.fc.outputs.comment-id}} != null
+      run: |
+        echo "${{steps.fc.outputs.comment-body}}" | sed '1d' | sed 's/> //' > tweet.txt
+        body=$(cat tweet.txt)
+        body="${body//'%'/'%25'}"
+        body="${body//$'\n'/'%0A'}"
+        body="${body//$'\r'/'%0D'}"
+        echo ::set-output name=body::$body
+        rm tweet.txt
+    - name: tweet the message
+      if: ${{steps.fc.outputs.comment-id}} != null
+      uses: ethomson/send-tweet-action@v1
+      with:
+        status: ${{steps.extract-tweet.outputs.body}}
+        consumer-key: ${{ secrets.TWITTER_API_KEY }}
+        consumer-secret: ${{ secrets.TWITTER_API_SECRET_KEY }}
+        access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+        access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}

--- a/.github/workflows/send_tweet.yaml
+++ b/.github/workflows/send_tweet.yaml
@@ -39,9 +39,9 @@ jobs:
         access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
         access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
     - name: clear tweet keyword
-       if: ${{steps.fc.outputs.comment-id}} != null
-       uses: peter-evans/create-or-update-comment@v1
-       with:
-         comment-id: ${{steps.fc.outputs.comment-id}}
-         edit-mode: replace
-         body: ${{env.TWEET_SENT_KEYWORD}}
+      if: ${{steps.fc.outputs.comment-id}} != null
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{steps.fc.outputs.comment-id}}
+        edit-mode: replace
+        body: ${{env.TWEET_SENT_KEYWORD}}

--- a/.github/workflows/send_tweet.yaml
+++ b/.github/workflows/send_tweet.yaml
@@ -5,7 +5,7 @@ on:
     types: [closed]
 env:
   TWEET_KEYWORD: '__[tweet]__'
-
+  TWEET_SENT_KEYWORD: '__[tweet sent]__'
 jobs:
   publish_tweet:
     runs-on: ubuntu-latest
@@ -38,3 +38,10 @@ jobs:
         consumer-secret: ${{ secrets.TWITTER_API_SECRET_KEY }}
         access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
         access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+    - name: clear tweet keyword
+       if: ${{steps.fc.outputs.comment-id}} != null
+       uses: peter-evans/create-or-update-comment@v1
+       with:
+         comment-id: ${{steps.fc.outputs.comment-id}}
+         edit-mode: replace
+         body: ${{env.TWEET_SENT_KEYWORD}}

--- a/.github/workflows/send_tweet.yaml
+++ b/.github/workflows/send_tweet.yaml
@@ -20,7 +20,7 @@ jobs:
         body-includes: ${{env.TWEET_KEYWORD}}
     - name: if tweet CI comment is found, extract tweet from comment body
       id: extract-tweet
-      if: ${{steps.fc.outputs.comment-id}} != null
+      if: ${{steps.fc.outputs.comment-id != null}}
       run: |
         echo "${{steps.fc.outputs.comment-body}}" | sed '1d' | sed 's/> //' > tweet.txt
         body=$(cat tweet.txt)
@@ -30,7 +30,7 @@ jobs:
         echo ::set-output name=body::$body
         rm tweet.txt
     - name: tweet the message
-      if: ${{steps.fc.outputs.comment-id}} != null
+      if: ${{steps.fc.outputs.comment-id != null}}
       uses: ethomson/send-tweet-action@v1
       with:
         status: ${{steps.extract-tweet.outputs.body}}
@@ -39,7 +39,7 @@ jobs:
         access-token: ${{secrets.TWITTER_ACCESS_TOKEN}}
         access-token-secret: ${{secrets.TWITTER_ACCESS_TOKEN_SECRET}}
     - name: clear tweet keyword
-      if: ${{steps.fc.outputs.comment-id}} != null
+      if: ${{steps.fc.outputs.comment-id != null}}
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{steps.fc.outputs.comment-id}}

--- a/.github/workflows/send_tweet.yaml
+++ b/.github/workflows/send_tweet.yaml
@@ -15,7 +15,7 @@ jobs:
       uses: peter-evans/find-comment@v1
       id: fc
       with:
-        issue-number: ${{ github.event.pull_request.number }}
+        issue-number: ${{github.event.pull_request.number}}
         comment-author: github-actions[bot]
         body-includes: ${{env.TWEET_KEYWORD}}
     - name: if tweet CI comment is found, extract tweet from comment body
@@ -34,10 +34,10 @@ jobs:
       uses: ethomson/send-tweet-action@v1
       with:
         status: ${{steps.extract-tweet.outputs.body}}
-        consumer-key: ${{ secrets.TWITTER_API_KEY }}
-        consumer-secret: ${{ secrets.TWITTER_API_SECRET_KEY }}
-        access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-        access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+        consumer-key: ${{secrets.TWITTER_API_KEY}}
+        consumer-secret: ${{secrets.TWITTER_API_SECRET_KEY}}
+        access-token: ${{secrets.TWITTER_ACCESS_TOKEN}}
+        access-token-secret: ${{secrets.TWITTER_ACCESS_TOKEN_SECRET}}
     - name: clear tweet keyword
       if: ${{steps.fc.outputs.comment-id}} != null
       uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/send_tweet.yaml
+++ b/.github/workflows/send_tweet.yaml
@@ -22,15 +22,13 @@ jobs:
       id: extract-tweet
       if: ${{steps.fc.outputs.comment-id != null}}
       run: |
-        echo "${{steps.fc.outputs.comment-body}}" | sed '1d' | sed 's/> //' > tweet.txt
+        body=$(echo "${{steps.fc.outputs.comment-body}}" | sed '1d' | sed 's/> //')
         # escape file content to preserve new lines
         # (see example in https://github.com/peter-evans/create-or-update-comment)
-        body=$(cat tweet.txt)
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"
         body="${body//$'\r'/'%0D'}"
         echo ::set-output name=body::$body
-        rm tweet.txt
     - name: tweet the message
       if: ${{steps.fc.outputs.comment-id != null}}
       uses: ethomson/send-tweet-action@v1

--- a/.github/workflows/send_tweet.yaml
+++ b/.github/workflows/send_tweet.yaml
@@ -23,6 +23,8 @@ jobs:
       if: ${{steps.fc.outputs.comment-id != null}}
       run: |
         echo "${{steps.fc.outputs.comment-body}}" | sed '1d' | sed 's/> //' > tweet.txt
+        # escape file content to preserve new lines
+        # (see example in https://github.com/peter-evans/create-or-update-comment)
         body=$(cat tweet.txt)
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"

--- a/.github/workflows/send_tweet.yaml
+++ b/.github/workflows/send_tweet.yaml
@@ -18,8 +18,6 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: github-actions[bot]
         body-includes: ${{env.TWEET_KEYWORD}}
-    - run: |
-        echo ${{ github.event.pull_request.number }} ${{ env.TWEET_KEYWORD }} ${{steps.fc.outputs.comment-id}}
     - name: if tweet CI comment is found, extract tweet from comment body
       id: extract-tweet
       if: ${{steps.fc.outputs.comment-id}} != null


### PR DESCRIPTION
Hello everyone!

As discussed in the [fortran-lang discourse](https://fortran-lang.discourse.group/t/tool-to-manage-tweets/322?u=pcosta), this PR implements a CI that:

1. Generates tweets by commenting on a PR
2. Publishes these tweets when the PR is merged

Please have a look, and feel free to test it by submitting a PR in this repo I created: [p-costa/piu-piu-sandbox](https://github.com/p-costa/piu-piu-sandbox).

If you are happy with it, to get it to work, one needs to create a twitter app, following the steps similar to those indicated here: [github.com/gr2m/twitter-together/blob/master/docs/01-create-twitter-app.md](https://github.com/gr2m/twitter-together/blob/master/docs/01-create-twitter-app.md) and add the corresponding keys and tokens to this repo.

I should thank the author of [find-comment](https://github.com/peter-evans/find-comment) for very promptly considering issues [#23](https://github.com/peter-evans/find-comment/issues/23) and [#24](https://github.com/peter-evans/find-comment/issues/24).

The tweets are published using [send-tweet-action](https://github.com/marketplace/actions/send-tweet-action), as per @LKedward suggestion.

__It works as follows:__

A comment in the PR starting with the keyword #tweet `text` will:
1. remove a previous tweet, if it exists.
2. add a new tweet to be published by the CI once the PR is merged.

A comment in the PR starting with the keyword #untweet will remove the tweet.

Then, when the PR is merged, the CI will look for a specific keyword (__[tweet]__) published by the GitHub actions bot, and, if it exists in the PR comment thread, it will be deployed for publication in the fortran-lang twitter account.