### PR TITLE
Add NWChem to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -663,6 +663,13 @@
   license: none
   version: none
 
+- name: NWChem
+  github: nwchemgit/nwchem
+  description: Open Source High-Performance Computational Chemistry
+  categories: scientific
+  tags: computational-chemistry parallel-computing electronic-structure-calculations molecular-simulations density-functional-theory hartree-fock quantum-chemistry
+  license: ECL-2.0
+
 - name: "OFF"
   github: szaghi/OFF
   description: Finite volume fluid dynamics


### PR DESCRIPTION
This PR adds NWChem to the package index, see #68.

- documentation: https://nwchemgit.github.io/
- repository: https://github.com/nwchemgit/nwchem