### PR TITLE
Add xtb to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -728,7 +728,7 @@
 - name: xtb
   github: grimme-lab/xtb
   description: Semiempirical Extended Tight-Binding Program Package
-  categories: scrientific
+  categories: scientific
   tags: quantum-chemistry computational-chemistry atomistic-simulations
   license: LGPL-3.0-or-later
 

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -725,6 +725,13 @@
   license: GNU GPL V2
   version: 2.8.4
 
+- name: xtb
+  github: grimme-lab/xtb
+  description: Semiempirical Extended Tight-Binding Program Package
+  categories: scrientific
+  tags: quantum-chemistry computational-chemistry atomistic-simulations
+  license: LGPL-3.0-or-later
+
 # --- Examples / demos / templates ---
 
 - name: Fortran 2018 examples


### PR DESCRIPTION
Disclaimer: *this is a project I'm personally involved with.*

This PR adds a `xtb` to the package index.

- documentation: https://xtb-docs.readthedocs.io/
- GH repository: https://github.com/grimme-lab/xtb
- builds with CMake and meson
- supports GCC 7.5 to 10.2, Intel 17 to 20, PGI 19.7 to 20.7
- OpenMP and OpenACC parallelisation
- CI testing is done for Ubuntu and OSX (no Windows yet)
- LGPL-3.0-or-later