### PR TITLE
Add wannier90 to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -717,6 +717,12 @@
   license: GNU GPL V2
   version: 12778
 
+- name: wannier90
+  github: wannier-developers/wannier90
+  description: The Maximally-Localised Generalised Wannier Functions Code
+  categories: scientific
+  tags: electronic-structure
+
 - name: WHIZARD
   url: https://whizard.hepforge.org/
   description: Particle Physics Monte Carlo Event Generator

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -717,7 +717,7 @@
   license: GNU GPL V2
   version: 12778
 
-- name: wannier90
+- name: Wannier90
   github: wannier-developers/wannier90
   description: The Maximally-Localised Generalised Wannier Functions Code
   categories: scientific


### PR DESCRIPTION
This PR adds wannier90 to the package index, it provides interfaces to some of the already listed open source electronic structure packages (QE, Abinit, ...).

- homepage: http://www.wannier.org/
- GH repository: https://github.com/wannier-developers/wannier90
- documentation: https://github.com/wannier-developers/wannier90/wiki
- GPL-2.0