### PR TITLE
Add: tapenade package

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -222,6 +222,13 @@
   tags:
   license: GPL-3.0
 
+- name: Tapenade
+  url: https://gitlab.inria.fr/tapenade/tapenade
+  description: A tool for automatic differentiation (forward/reverse) of Fortran and c programs
+  categories: programming numerical
+  tags: algorithmic derivative ad
+  license: MIT
+
 # --- Data types ---
 
 - name: Fortran template library


### PR DESCRIPTION
I was pleasantly surprised to see this previously closed-source commercially-licensed tool is now open source under MIT!
IMO, this tool is the state of the art in automatic differentiation for Fortran. It has a long history and is hence quite robust.
See also the [discussion on discourse](https://fortran-lang.discourse.group/t/automatic-differentiation-of-fortran-code-opinions/369/10).

(It doesn't have gitlab stars because it's a self-hosted instance of gitlab I think.)