### PR TITLE
Add PSBLAS to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -603,6 +603,12 @@
   categories: numerical
   tags: linear algebra parallel mpi openmp cuda hip
 
+- name: PSBLAS
+  github: sfillipone/psblas3
+  description: Parallel Sparse BLAS
+  categories: numerical data-types
+  tags: linear algebra mpi
+
 - name: GALAHAD
   github: ralna/GALAHAD
   description: Modules for nonlinear optimization


### PR DESCRIPTION
Adds https://github.com/sfilippone/psblas3

This is an established library for sparse matrix linear algebra operations. It is described in several publications.

Perhaps it will be necessary to update the license manually.