### PR TITLE
Add TOML-Fortran to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -448,6 +448,13 @@
   tags: validation
   license: BSD-2-Clause
 
+- name: toml-f
+  github: toml-f/toml-f
+  description: A TOML parser implementation for data serialization and deserialization in Fortran
+  categories: io
+  tags: toml
+  license: "Apache-2.0 OR MIT"
+
 # --- Graphics ---
 
 - name: f03gl


### PR DESCRIPTION
This PR adds an entry for the [`toml-f`](https://github.com/toml-f) library. The library implements a TOML 1.0.0-rc3 compliant parser in pure Fortran. The project is currently in beta stage (there is no v1.0 release for now), but is already successfully used in fpm.

Since the projects main build system is still meson, with CMake and fpm supported as well, I think the package index is better suited than the fpm-registry.