### PR TITLE
Add missing packages from list of popular Fortran projects

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -979,6 +979,12 @@
   categories: scientific
   version: none
 
+- name: MITgcm
+  github: MITgcm/MITgcm
+  description: M.I.T General Circulation Model master code and documentation repository
+  categories: scientific
+  keywords: ocean-modelling gfd automatic-differentiation data-assimilation exoplanets climate-science
+
 - name: Specfem3D
   github: geodynamics/specfem3d
   description: Simulates acoustic (fluid), elastic (solid), coupled acoustic/elastic, poroelastic or seismic wave propagation in any type of conforming mesh of hexahedra (structured or not)

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -22,7 +22,7 @@
 #
 # When adding a new library:
 #  - Check it shows up in the expected category page(s)
-#  - Temporarily use the category 'preview' and check 
+#  - Temporarily use the category 'preview' and check
 #     check the badges render correctly at /explore/category/preview
 #
 # No need to repeat keywords from 'description' in 'tags'
@@ -82,7 +82,7 @@
   categories: libraries
   tags: redo
   version: none
- 
+
 - name: Futility
   github: CASL/Futility
   description: Fortran utilities including unit test harness, arbitrary length strings, parameter list objects, timers, geometry definitions, file wrappers, linear algebra tools, and parallel computing support
@@ -90,11 +90,16 @@
   version: none
   license: "Apache v2.0"
 
+- name: Fortran Astrodynamics Toolkit
+  github: jacobwilliams/Fortran-Astrodynamics-Toolkit
+  description: A Modern Fortran Library for Astrodynamics
+  categories: libraries
+
 # --- Interfaces ---
 
 - name: forpy
   github: ylikx/forpy
-  description: allows you to use Python features in Fortran 
+  description: allows you to use Python features in Fortran
   categories: interfaces
   tags: dict list tuple numpy python matplotlib scipy
   license: GPL-3.0
@@ -104,7 +109,7 @@
   github: modern-fortran/tcp-client-server
   description: A minimal Fortran TCP client and server demonstrating c interoperability
   categories: interfaces examples
-  tags: 
+  tags:
   version: none
 
 - name: clfortran
@@ -119,7 +124,7 @@
   github: urbanjost/M_process
   description: Read and write lines to or from a process from Fortran via a C wrapper
   categories: interfaces
-  tags: 
+  tags:
   version: none
 
 - name: M_system
@@ -131,7 +136,7 @@
 
 - name: Focal
   github: LKedward/focal
-  description: A module library which wraps calls to the OpenCL runtime API with a higher abstraction level 
+  description: A module library which wraps calls to the OpenCL runtime API with a higher abstraction level
   categories: interfaces
   tags: gpu compute accelerator
 
@@ -141,6 +146,16 @@
   categories: interfaces programming
   tags: posix libc
   license: BSD-2-clause
+
+- name: node-fortran
+  github: IonicaBizau/node-fortran
+  description: Fortran bridge for Node.js which allows you to run Fortran code from Node.js
+  categories: interfaces
+
+- name: node.fortran
+  github: IonicaBizau/node.fortran
+  description: Execute Node.js in your Fortran programs
+  categories: interfaces
 
 - name: sqliteff
   url: https://gitlab.com/everythingfunctional/sqliteff
@@ -189,7 +204,7 @@
 - name: vegetables
   url: https://gitlab.com/everythingfunctional/vegetables
   description: A Fortran testing framework written using functional programming principles.
-  categories: programming 
+  categories: programming
   tags: testing assert
   license: MIT
   version: 4.0
@@ -234,7 +249,7 @@
 - name: Fortran template library
   github: SCM-NV/ftl
   description: Generic containers, versatile algorithms, easy string manipulation, and more
-  categories: data-types 
+  categories: data-types
   tags: resizeable array container linked list hash map regex string shared pointer
   version: none
   license: LGPL-3.0-or-later
@@ -268,7 +283,7 @@
 
 - name: datetime-fortran
   github: wavebitscientific/datetime-fortran
-  description: Date and time manipulation 
+  description: Date and time manipulation
   categories: data-types
   tags: day year month calendar weekday clock
   license: MIT
@@ -286,14 +301,14 @@
   github: jannisteunissen/lookup_table_fortran
   description: Linear lookup table implemented in modern Fortran
   categories: data-types
-  tags: 
+  tags:
   version: none
 
 - name: FyCollections
   url: https://bitbucket.org/aradi/fycollections/src/develop/
   description: generic collection templates for Fortran
   categories: data-types
-  tags: 
+  tags:
   license: BSD-2-Clause
 
 
@@ -310,14 +325,14 @@
   github: urbanjost/M_strings
   description: Fortran string manipulations
   categories: strings
-  tags: upper lower quoted join replace white space string conversion tokens split 
+  tags: upper lower quoted join replace white space string conversion tokens split
   version: none
 
 - name: Strings for Fortran
   url: https://gitlab.com/everythingfunctional/strff
   description: A library of string functions for Fortran.
   categories: strings
-  tags: 
+  tags:
   license: MIT
 
 - name: iso_varying_string
@@ -354,7 +369,7 @@
   github: szaghi/VTKFortran
   description: Library to parse and emit files conforming VTK (XML) standard
   categories: io
-  tags: 
+  tags:
   license: GPL-3.0
   version: none
 
@@ -369,7 +384,7 @@
   github: andreww/fox
   description: A Fortran XML library
   categories: io
-  tags: 
+  tags:
   license: BSD-3-Clause
   version: none
 
@@ -377,7 +392,7 @@
   github: victorsndvg/FEconv
   description: utility and library for converting between mesh and finite element field formats
   categories: io
-  tags: ansys msh nastran bdf vtk 
+  tags: ansys msh nastran bdf vtk
   version: none
 
 - name: h5fortran
@@ -396,14 +411,14 @@
   github: jacobwilliams/fortran-csv-module
   description: Read and write CSV Files using modern Fortran
   categories: io
-  tags: 
+  tags:
   license: BSD-3-Clause
 
 - name: M_IO
   github: urbanjost/M_io
   description: Fortran module for common I/O tasks
   categories: io
-  tags: delete slurp swallow dirname split path 
+  tags: delete slurp swallow dirname split path
   license: Unlicense
   version: none
 
@@ -411,7 +426,7 @@
   url: https://gitlab.com/everythingfunctional/jsonff
   description: Routines for building JSON structures in Fortran
   categories: io
-  tags: 
+  tags:
   license: MIT
 
 - name: NPY for Fortran
@@ -423,7 +438,7 @@
 - name: FiNeR
   github: szaghi/FiNeR
   description: INI ParseR and generator
-  categories: io 
+  categories: io
   tags: config
   license: GPL-3.0
 
@@ -431,14 +446,14 @@
   github: jannisteunissen/config_fortran
   description: Configuration file parser for Fortran
   categories: io
-  tags: 
+  tags:
   version: none
 
 - name: Parser for Fortran
   url: https://gitlab.com/everythingfunctional/parff
   description: The foundations of a functional style parser combinator library
   categories: io
-  tags: 
+  tags:
   license: MIT
 
 - name: Serialbox
@@ -483,7 +498,7 @@
   github: kookma/ogpf
   description: Object based interface to GnuPlot for Fortran
   categories: graphics interfaces
-  tags: animation plot surface contour 
+  tags: animation plot surface contour
   license: MIT
   version: none
 
@@ -497,7 +512,7 @@
   github: urbanjost/M_draw
   description: Low-level vector graphics library
   categories: graphics
-  tags: 
+  tags:
   version: none
 
 - name: fortran-xlib
@@ -511,7 +526,7 @@
   github: interkosmos/fortran-sdl2
   description: A collection of ISO C binding interfaces to Simple DirectMedia Layer 2.0 (SDL 2.0), for multimedia and game programming in Fortran
   categories: graphics interfaces
-  tags: 
+  tags:
   version: none
 
 # --- Numerical libraries ---
@@ -566,7 +581,7 @@
 
 - name: ParaMonte
   github: cdslaborg/paramonte
-  description: A general-purpose high-performance MPI/Coarray-parallel Monte Carlo simulation library implemented in Fortran 2018 with interfaces to C/C++/Fortran/MATLAB/Python 
+  description: A general-purpose high-performance MPI/Coarray-parallel Monte Carlo simulation library implemented in Fortran 2018 with interfaces to C/C++/Fortran/MATLAB/Python
   categories: numerical
   tags: parallel mpi coarray monte carlo mcmc c cpp matlab python statistics bayesian stochastic optimization sampling integration machine learning
   version: 1.0.0
@@ -587,22 +602,22 @@
 
 - name: fgsl
   github: reinh-bader/fgsl
-  description: Fortran interface to the GNU Scientific Library 
+  description: Fortran interface to the GNU Scientific Library
   categories: numerical interfaces
-  tags: 
+  tags:
 
 - name: SciFortran
   github: aamaricci/SciFortran
   description: collection of fortran modules and procedures for scientific calculations.
   categories: numerical
-  tags: 
+  tags:
   version: none
 
 - name: Los Alamos Grid Toolbox (LaGriT)
   github: lanl/LaGriT
   description: a library of user callable tools that provide mesh generation, mesh optimization and dynamic mesh maintenance
   categories: numerical
-  tags: 
+  tags:
   license: BSD
 
 - name: DBCSR
@@ -628,7 +643,7 @@
   github: jacobwilliams/slsqp
   description: SLSQP nonlinear constrained optimizer
   categories: numerical
-  tags: nonlinear programming equality inequality constraints 
+  tags: nonlinear programming equality inequality constraints
   license: BSD-3-Clause AND MIT
 
 - name: NumDiff
@@ -642,7 +657,7 @@
   url: https://gitlab.com/everythingfunctional/quaff
   description: Quantities for Fortran. Make math with units more convenient
   categories: numerical
-  tags: 
+  tags:
   license: MIT
 
 - name: rng_fortran
@@ -710,6 +725,17 @@
   categories: scientific
   license: Public domain
 
+- name: lesgo
+  github: lesgo-jhu/lesgo
+  descriptipon: The Large-Eddy Simulation framework from the Turbulence Research Group at Johns Hopkins University
+  categories: scientific
+  version: none
+
+- name: Tracmass
+  github: TRACMASS/tracmass
+  description: Lagrangian particle tracking code
+  categories: scientific
+
 - name: fds
   github: firemodels/fds
   description: Large-eddy simulation code for low-speed flows, with an emphasis on smoke and heat transport from fires.
@@ -721,6 +747,11 @@
   description: Quantum ESPRESSO is an integrated suite of Open-Source computer codes for electronic-structure calculations and materials modeling at the nanoscale
   categories: scientific
   tags: electronic structure calculations quantum chemistry physics molecular dynamics mpi
+
+- name: BandUP
+  github: band-unfolding/bandup
+  description: Band Unfolding code for Plane-wave based calculations
+  categories: scientific
 
 - name: fluidity
   github: FluidityProject/fluidity
@@ -741,7 +772,7 @@
 
 - name: cp2k
   github: cp2k/cp2k
-  description: quantum chemistry and solid state physics software package that can perform atomistic simulations 
+  description: quantum chemistry and solid state physics software package that can perform atomistic simulations
   categories: scientific
   tags: quantum chemistry physics molecular dynamics metadynamics mpi cuda
   license: GPL-2.0
@@ -766,9 +797,17 @@
   categories: scientific
   tags: electronic structure calculations quantum chemistry physics molecular dynamics mpi
 
+- name: NASTRAN 93
+  github: nasa/NASTRAN-93
+  description: NASTRAN is the NASA Structural Analysis System, a finite element analysis program (FEA)
+  categories: scientific
+  tags: finite element structural
+  license: NASA-1.3
+  version: none
+
 - name: NASTRAN 95
   github: nasa/NASTRAN-95
-  description: NASA Structural Analysis System, a finite element analysis program (FEA) completed in the early 1970's 
+  description: NASA Structural Analysis System, a finite element analysis program (FEA) completed in the early 1970's
   categories: scientific
   tags: finite element structural eigne stability loads
   license: NASA-1.3
@@ -802,6 +841,18 @@
   description: A code for fast, massively-parallel direct numerical simulations (DNS) of canonical flows
   categories: scientific
   tags: fluid dynamics fluid simulation computational fluid dynamics turbulence high performance computing hpc cfd
+  version: none
+
+- name: ICAR
+  github: NCAR/icar
+  description: The Intermediate Complexity Atmospheric Research model
+  categories: scientific
+  version: none
+
+- name: aenet
+  github: atomisticnet/aenet
+  description: Atomic interaction potentials based on artificial neural networks
+  categories: scientific
   version: none
 
 - name: ADflow
@@ -850,6 +901,100 @@
   license: GPL-2.0-or-later
   version: 2.8.4
 
+- name: HANDE
+  github: hande-qmc/hande
+  description: Open source stochastic quantum chemistry
+  categories: numerical scientific
+  tags: qmc electronic-structure
+  version: none
+
+- name: OpenMolcas
+  url: https://gitlab.com/Molcas/OpenMolcas
+  description: Quantum chemistry software package for multiconfigurational approaches to the electronic structure
+  categories: scientific
+  tags: electronic-structure casscf caspt2
+  license: LGPL-2.1
+
+- name: Octopus
+  url: https://gitlab.com/octopus-code/octopus
+  description: Real-space Time-Dependent Density Functional Theory code
+  categories: scientific
+  tags: electronic-structure
+  license: GPL-2.0
+  version: none
+
+- name: MOM6
+  github: NOAA-GFDL/MOM6
+  description: Modular Ocean Model
+  categories: scientific
+  license: GPL-3.0
+  version: none
+
+- name: FMS
+  github: NOAA-GFDL/FMS
+  description: Flexible Modeling System
+  categories: scientific
+
+- name: SNAP
+  github: lanl/SNAP
+  description: proxy application to model the performance of a modern discrete ordinates neutral particle transport application
+  categories: scientific
+  license: BSD-3-Clause
+  version: none
+
+- name: CTSM
+  github: ESCOMP/CTSM
+  description: The Community Terrestrial Systems Model
+  categories: scientific
+  license: BSD-3-Clause
+
+- name: MPAS-Model
+  github: MPAS-Dev/MPAS-Model
+  description: collaborative project for developing atmosphere, ocean, and other earth-system simulation components for use in climate, regional climate, and weather studies
+  categories: scientific
+  license: BSD-3-Clause
+
+- name: CFL3D
+  github: nasa/CFL3D
+  description: Structured-grid, cell-centered, upwind-biased, Reynolds-averaged Navier-Stokes (RANS) code
+  categories: scientific
+  license: Apache-2.0
+  version: none
+
+- name: CompDam_DGD
+  github: nasa/CompDam_DGD
+  description: continuum damage mechanics (CDM) material model intended for use with the Abaqus finite element code
+  categories: scientific
+  license: NASA-1.3
+
+- name: OpenSWPC
+  github: tktmyd/OpenSWPC
+  description: A Seismic Wave Propagation Code by Parallel Finite Difference Method
+  categories: scientific
+
+- name: flexi
+  github: flexi-framework/flexi
+  description: Open Source High-Order Unstructured Discontinuous Galerkin Fluid Dynamics Solver
+  categories: scientific
+  version: none
+
+- name: Specfem3D
+  github: geodynamics/specfem3d
+  description: Simulates acoustic (fluid), elastic (solid), coupled acoustic/elastic, poroelastic or seismic wave propagation in any type of conforming mesh of hexahedra (structured or not)
+  categories: scientific
+
+- name: DFT-D4
+  github: dftd4/dftd4
+  description: A Generally Applicable Atomic-Charge Dependent London Dispersion Correction
+  categories: scientific
+  tags: dft-d dispersion-correction
+
+- name: libmbd
+  github: jhrmnn/libmbd
+  description: Many-body dispersion library
+  categories: scientific
+  tags: dispersion-correction
+
 - name: xtb
   github: grimme-lab/xtb
   description: Semiempirical Extended Tight-Binding Program Package
@@ -872,7 +1017,7 @@
   categories: examples
   tags:
   version: none
-  
+
 - name: Numerical methods in fortran
   github: planelles20/numerical-methods-fortran
   description: Solving linear, nonlinear equations, ordinary differential equations
@@ -888,35 +1033,8 @@
   version: none
   license: Apache2.0
 
-- name: HANDE
-  github: hande-qmc/hande
-  description: Open source stochastic quantum chemistry
-  categories: numerical scientific
-  tags: qmc electronic-structure
+- name: Tsunami
+  github: modern-fortran/tsunami
+  description: A parallel shallow water equations solver
+  categories: examples
   version: none
-
-- name: OpenMolcas
-  url: https://gitlab.com/Molcas/OpenMolcas
-  description: Quantum chemistry software package for multiconfigurational approaches to the electronic structure
-  categories: scientific
-  tags: electronic-structure casscf caspt2
-  license: LGPL-2.1
-
-- name:
-  url: https://gitlab.com/octopus-code/octopus
-  description: Real-space Time-Dependent Density Functional Theory code
-  categories: scientific
-  tags: electronic-structure
-  license: GPL-2.0
-
-- name: DFT-D4
-  github: dftd4/dftd4
-  description: A Generally Applicable Atomic-Charge Dependent London Dispersion Correction
-  categories: scientific
-  tags: dft-d dispersion-correction
-
-- name: libmbd
-  github: jhrmnn/libmbd
-  description: Many-body dispersion library
-  categories: scientific
-  tags: dispersion-correction

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -94,6 +94,7 @@
   github: jacobwilliams/Fortran-Astrodynamics-Toolkit
   description: A Modern Fortran Library for Astrodynamics
   categories: libraries
+  license: BSD-3-Clause
 
 # --- Interfaces ---
 
@@ -982,6 +983,7 @@
   github: geodynamics/specfem3d
   description: Simulates acoustic (fluid), elastic (solid), coupled acoustic/elastic, poroelastic or seismic wave propagation in any type of conforming mesh of hexahedra (structured or not)
   categories: scientific
+  version: none
 
 - name: DFT-D4
   github: dftd4/dftd4


### PR DESCRIPTION
This should add *all* the remaining packages from https://github.com/fortran-lang/fortran-lang.org/issues/68 which have an open source license.

*Important:* since my background is electronic structure theory, I'm mostly not familiar with weather modeling or astrodynamics, which many of those projects are targeting. Somebody with experience in this fields should have a look over the descriptions and add tags as appropriate.

This PR will eventually close https://github.com/fortran-lang/fortran-lang.org/issues/68.