### PR TITLE
Correct Compiler page and tutorial regarding Intel oneAPI and PGI to NVIDIA

### DIFF
--- a/compilers.md
+++ b/compilers.md
@@ -66,14 +66,9 @@ platforms include supporting tools for software development: source file
 polishers, dependency generator for module and include files, call-graph
 generator, interface builder and a precision unifier.
 
-### PGI
+### NVIDIA
 
-[PGI compilers](https://www.pgroup.com/products/index.htm)
-deliver the performance you need on CPUs, with OpenACC and CUDA
-Fortran for HPC applications development on GPU-accelerated systems. OpenACC and
-CUDA programs can run several times faster on a single Tesla V100 GPU compared
-to all the cores of a dual-socket server, and interoperate with MPI and OpenMP
-to deliver the full power of today’s multi-GPU servers.
+The [NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk) C, C++, and Fortran compilers, former [PGI compilers](https://www.pgroup.com/products/index.htm), support GPU acceleration of HPC modeling and simulation applications with standard C++ and Fortran, OpenACC® directives, and CUDA®. GPU-accelerated math libraries maximize performance on common HPC algorithms, and optimized communications libraries enable standards-based multi-GPU and scalable systems programming.
 
 ### HPE / Cray
 

--- a/compilers.md
+++ b/compilers.md
@@ -43,10 +43,8 @@ compiler.
 
 ### Intel
 
-[Intel Parallel Studio XE](https://software.intel.com/en-us/parallel-studio-xe)
-is Intel's suite of compilers, tools, and libraries for Fortran, C, C++, and
-Python. Intel offers the Linux edition of their compiler suite for free for
-[open source contributors](https://software.intel.com/en-us/parallel-studio-xe/choose-download/open-source-contributor).
+[Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/tools/oneapi/all-toolkits.html) successor to  Intel® Parallel Studio XE and Intel® System Studio, offers a unified toolset to develop and deploy applications and solutions across CPU, GPU, and FPGA architectures. Toolkits include the new DPC++ programming language, as well as familiar C, C++ and Fortran languages. The Intel® Fortran Compiler Classic (ifort driver) in the Intel® oneAPI HPC Toolkit includes a full implementation of the Fortran 2018 standard. You can find [installation guides](https://software.intel.com/content/www/us/en/develop/articles/installation-guide-for-intel-oneapi-toolkits.html) for Linux, Windows and macOS. Note that Intel® oneAPI is free to install and use for commercial and non-commercial purposes.
+
 
 ### NAG
 
@@ -60,14 +58,10 @@ platforms include supporting tools for software development: source file
 polishers, dependency generator for module and include files, call-graph
 generator, interface builder and a precision unifier.
 
-### PGI
+### NVIDIA
 
-[PGI compilers](https://www.pgroup.com/products/index.htm)
-deliver the performance you need on CPUs, with OpenACC and CUDA
-Fortran for HPC applications development on GPU-accelerated systems. OpenACC and
-CUDA programs can run several times faster on a single Tesla V100 GPU compared
-to all the cores of a dual-socket server, and interoperate with MPI and OpenMP
-to deliver the full power of today’s multi-GPU servers.
+The [NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk) C, C++, and Fortran compilers, former [PGI compilers](https://www.pgroup.com/products/index.htm), support GPU acceleration of HPC modeling and simulation applications with standard C++ and Fortran, OpenACC® directives, and CUDA®. GPU-accelerated math libraries maximize performance on common HPC algorithms, and optimized communications libraries enable standards-based multi-GPU and scalable systems programming.
+
 
 ### HPE / Cray
 

--- a/compilers.md
+++ b/compilers.md
@@ -43,8 +43,10 @@ compiler.
 
 ### Intel
 
-[Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/tools/oneapi/all-toolkits.html) successor to  Intel® Parallel Studio XE and Intel® System Studio, offers a unified toolset to develop and deploy applications and solutions across CPU, GPU, and FPGA architectures. Toolkits include the new DPC++ programming language, as well as familiar C, C++ and Fortran languages. The Intel® Fortran Compiler Classic (ifort driver) in the Intel® oneAPI HPC Toolkit includes a full implementation of the Fortran 2018 standard. You can find [installation guides](https://software.intel.com/content/www/us/en/develop/articles/installation-guide-for-intel-oneapi-toolkits.html) for Linux, Windows and macOS. Note that Intel® oneAPI is free to install and use for commercial and non-commercial purposes.
-
+[Intel Parallel Studio XE](https://software.intel.com/en-us/parallel-studio-xe)
+is Intel's suite of compilers, tools, and libraries for Fortran, C, C++, and
+Python. Intel offers the Linux edition of their compiler suite for free for
+[open source contributors](https://software.intel.com/en-us/parallel-studio-xe/choose-download/open-source-contributor).
 
 ### NAG
 
@@ -58,10 +60,14 @@ platforms include supporting tools for software development: source file
 polishers, dependency generator for module and include files, call-graph
 generator, interface builder and a precision unifier.
 
-### NVIDIA
+### PGI
 
-The [NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk) C, C++, and Fortran compilers, former [PGI compilers](https://www.pgroup.com/products/index.htm), support GPU acceleration of HPC modeling and simulation applications with standard C++ and Fortran, OpenACC® directives, and CUDA®. GPU-accelerated math libraries maximize performance on common HPC algorithms, and optimized communications libraries enable standards-based multi-GPU and scalable systems programming.
-
+[PGI compilers](https://www.pgroup.com/products/index.htm)
+deliver the performance you need on CPUs, with OpenACC and CUDA
+Fortran for HPC applications development on GPU-accelerated systems. OpenACC and
+CUDA programs can run several times faster on a single Tesla V100 GPU compared
+to all the cores of a dual-socket server, and interoperate with MPI and OpenMP
+to deliver the full power of today’s multi-GPU servers.
 
 ### HPE / Cray
 

--- a/learn/os_setup/choose_compiler.md
+++ b/learn/os_setup/choose_compiler.md
@@ -6,8 +6,6 @@ permalink: /learn/os_setup/choose_compiler
 
 A comprehensive list of available compilers is provided [here]({{site.baseurl}}/compilers). In this guide, we will focus only on those that are free to install and use.
 
-Of those listed at the link above, open source and free are GFortran (with OpenCoarrays), Flang, and LFortran. Finally, NVFortran and IFort* are commercial with free community editions.
+Of those listed at the link above, open source and free are GFortran (with OpenCoarrays), Flang, and LFortran. NVIDIA and INTEL offer their compilers for free and as of the latest update of this tutorial, NVFortran (NVIDIA) is available only for Linux systems, while Intel oneAPI is available for Linux, Windows and macOS systems. Both are well documented and readers can find detailed information about installing and using them on their websites respectively. 
 
-_Note_: *IFort (Intel's Fortran Compiler) does not offer a free community edition in general. However, if you are a student, educator, or open-source contributor, you may [qualify for free software](https://software.intel.com/content/www/us/en/develop/articles/qualify-for-free-software.html).
-
-Both NVFortran (NVIDIA) and IFort (Intel) are well documented and readers can find detailed information about installing and using them on their websites respectively. In the next chapter, we use GFortran for the tutorial as it is a mature open source compiler. We encourage users to also try other open source and commercial compilers.
+In the next chapter, we use GFortran for the tutorial as it is a mature open source compiler. We encourage users to also try other open source and commercial compilers.

--- a/learn/os_setup/index.md
+++ b/learn/os_setup/index.md
@@ -10,7 +10,7 @@ permalink: /learn/os_setup
 ---
 <span style="color:grey; font-size:0.8em">*Authors: Stavros Meskos, Laurence Kedward, Arjen Markus, Ondřej Čertík, Milan Curcic*</span>
 
-<span style="color:grey; font-size:0.8em">*Last update: 19-Oct-2020*</span> 
+<span style="color:grey; font-size:0.8em">*Last update: 19-Dec-2020*</span> 
 
 ---
 


### PR DESCRIPTION
This is a minor correction PR about INTEL and NVIDIA (former PGI) at both the "compilers" page and at the mini-book "setting up your os".