### PR TITLE
Use setup-ruby 2.7 to fix CI build

### DIFF
--- a/.github/workflows/buildPRPreview.yml
+++ b/.github/workflows/buildPRPreview.yml
@@ -38,6 +38,11 @@ jobs:
         path: ${{env.PUBLISH_DIR}}
         ref: 'gh-pages' 
     
+    # Install ruby 2.7.x
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+
     # Setup Jekyll in SRC_DIR
     - name: Setup Jekyll
       run: |

--- a/.github/workflows/buildSite.yml
+++ b/.github/workflows/buildSite.yml
@@ -32,6 +32,11 @@ jobs:
       with:
         path: ${{env.PUBLISH_DIR}}
         ref: 'gh-pages'
+    
+    # Install ruby 2.7.x
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
 
     # Setup Jekyll in SRC_DIR
     - name: Setup Jekyll


### PR DESCRIPTION
Fixes #184 

Github [changed the default Ruby binaries](https://github.com/actions/virtual-environments/issues/2193) on the Ubuntu CI image which affected the installation of bundler.

This PR uses the `setup-ruby` action to select the correct version of Ruby.

[Tested successfully](https://github.com/LKedward/fortran-lang.github.io/runs/1584357004) on my fork.