### PR TITLE
Add links to fpm contributing guidelines

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -62,6 +62,11 @@ description: Collaboration for the advancement of Fortran
             Documentation </b></a>
             &ensp;
         </span>
+        <span style="display: inline-block;">
+          <i class="fab fa-git-alt"></i>
+          <a href="https://github.com/fortran-lang/fpm/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener"><b>
+          Contributing </b></a>
+        </span>
 
 
         <h3><i data-feather="globe"></i>
@@ -139,6 +144,7 @@ description: Collaboration for the advancement of Fortran
       </p>
       <ul>
         <li> <a href="https://github.com/fortran-lang/stdlib/blob/master/WORKFLOW.md" target="_blank" rel="noopener">Contributor guide for stdlib</a> </li>
+        <li> <a href="https://github.com/fortran-lang/fpm/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener">Contributor guide for fpm</a> </li>
         <li> <a href="https://github.com/fortran-lang/fortran-lang.org/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener">Contributor guide for fortran-lang.org</a> </li>
       </ul>
   </div>


### PR DESCRIPTION
The fpm contributing guidelines are not yet linked from the webpage. This PR adds links on the community page to the fpm contributor guide.