### PR TITLE
Fix author/maintainer output in fpm registry

### DIFF
--- a/.github/workflows/buildSite.yml
+++ b/.github/workflows/buildSite.yml
@@ -49,9 +49,7 @@ jobs:
     # Download latest fpm-registry index
     - name: Download fpm-registry index
       run: |
-        cd ${{env.SRC_DIR}}/_data
-        wget ${{env.FPM_INDEX}}
-        mv index.json fpm_registry_index.json
+        wget ${{env.FPM_INDEX}} -O ${{env.SRC_DIR}}/_data/fpm_registry_index.json
 
     # Run Jekyll build and copy output to PUBLISH_DIR
     - name: Build Jekyll Site

--- a/packages/category/fpm.html
+++ b/packages/category/fpm.html
@@ -50,8 +50,8 @@ feather-icon: package
               </tr>
 
               <tr><td colspan="3" class="light small">
-                <b>Author: </b>  {{ vers[1].author }} &nbsp &nbsp
-                <b>Maintainer: </b>  {{ vers[1].maintainer }}
+                <b>Author: </b>  {{ vers[1].author | join: " and " }} &nbsp &nbsp
+                <b>Maintainer: </b>  {{ vers[1].maintainer | join: " and " }}
               </td></tr>
               {% if vers[1].description %}
               <tr><td colspan="3" class="light small">


### PR DESCRIPTION
Joins arrays of author/maintainer names with `" and "`.

Also, simplifies fetching of registry in workflow file.