### PR TITLE
Monthly newsletter for February 2021

### DIFF
--- a/_posts/2021-02-01-Fortran-Newsletter-February-2021.md
+++ b/_posts/2021-02-01-Fortran-Newsletter-February-2021.md
@@ -1,0 +1,170 @@
+---
+layout: post
+title: "Fortran newsletter: February 2021"
+category: newsletter
+author: Sebastian Ehlert
+---
+
+Welcome to the February 2021 edition of the monthly Fortran newsletter.
+The newsletter comes out at the beginning of every month and details
+Fortran news from the previous month.
+
+<ul id="page-nav"></ul>
+
+## fortran-lang.org
+
+This month we've had a few updates to the website:
+
+* [#190](https://github.com/fortran-lang/fortran-lang.org/pull/190) (WIP):
+  Add links to fpm contributing guidelines
+
+Ongoing work:
+
+* [#191](https://github.com/fortran-lang/fortran-lang.org/pull/191) (WIP):
+  Fix author/maintainer output in fpm registry
+* [#187](https://github.com/fortran-lang/fortran-lang.org/pull/187) (WIP):
+  Correct compiler page and tutorial regarding Intel oneAPI and PGI to NVIDIA
+* [#174](https://github.com/fortran-lang/fortran-lang.org/issues/174) (WIP):
+  We are searching for a representative Fortran code snippet for the website and are looking forward to suggestions.
+
+[Let us know](https://github.com/fortran-lang/fortran-lang.org/issues) if you have any suggestions for the website and its content.
+We welcome any new contributors to the website and the tutorials page in particular - see the [contributor guide](https://github.com/fortran-lang/fortran-lang.org/blob/master/CONTRIBUTING.md) for how to get started.
+
+## Fortran Standard Library
+
+Here's what's new in `stdlib`:
+
+* [#303](https://github.com/fortran-lang/stdlib/pull/303),
+  [#301](https://github.com/fortran-lang/stdlib/pull/301),
+  [#294](https://github.com/fortran-lang/stdlib/pull/294):
+  Fixes and improvements for the manual Makefile build
+* [#293](https://github.com/fortran-lang/stdlib/pull/293):
+  Write a more verbose introduction to building stdlib
+* [#291](https://github.com/fortran-lang/stdlib/pull/291):
+  Export package files (CMake and pkg-config)
+* [#290](https://github.com/fortran-lang/stdlib/pull/290):
+  Rename CMake project from stdlib to fortran\_stdlib
+* [#288](https://github.com/fortran-lang/stdlib/pull/288):
+  Follow GNU install conventions
+* [#284](https://github.com/fortran-lang/stdlib/pull/284):
+  Required changes to be able to use `stdlib` as a subproject in CMake
+* [CMake example](https://github.com/fortran-lang/stdlib-cmake-example)
+  integration of the Fortran standard library in CMake projects
+
+Work in progress:
+
+* [#304](https://github.com/fortran-lang/stdlib/pull/304) (WIP):
+  Add supported compilers MinGW 8, 9, 10
+* [#269](https://github.com/fortran-lang/stdlib/pull/269) (WIP):
+  Implementation of a module for handling lists of strings
+* [#271](https://github.com/fortran-lang/stdlib/pull/271) (WIP),
+  [#272](https://github.com/fortran-lang/stdlib/pull/272) (WIP),
+  [#273](https://github.com/fortran-lang/stdlib/pull/273) (WIP),
+  [#276](https://github.com/fortran-lang/stdlib/pull/276) (WIP),
+  [#278](https://github.com/fortran-lang/stdlib/pull/278) (WIP):
+  Implementation of the `stdlib_stats_distribution` modules.
+  It provides probability distribution and statistical functions.
+* [#189](https://github.com/fortran-lang/stdlib/pull/189) (WIP):
+  Initial implementation of sparse matrices.
+
+Don't hesitate to test and review these pull requests!
+
+Otherwise, ongoing discussions continue about usability of `stdlib`
+([#7](https://github.com/fortran-lang/stdlib/issues/7),
+[#215](https://github.com/fortran-lang/stdlib/issues/215),
+[#279](https://github.com/fortran-lang/stdlib/issues/279),
+[#280](https://github.com/fortran-lang/stdlib/issues/280),
+[#285](https://github.com/fortran-lang/stdlib/issues/285)),
+and new implementations for `stdlib`
+([#135](https://github.com/fortran-lang/stdlib/issues/135),
+[#212](https://github.com/fortran-lang/stdlib/issues/212),
+[#234](https://github.com/fortran-lang/stdlib/issues/234),
+[#241](https://github.com/fortran-lang/stdlib/issues/241),
+[#258](https://github.com/fortran-lang/stdlib/issues/258),
+[#259](https://github.com/fortran-lang/stdlib/issues/259),
+[#262](https://github.com/fortran-lang/stdlib/issues/262),
+[#268](https://github.com/fortran-lang/stdlib/issues/268),
+[#277](https://github.com/fortran-lang/stdlib/issues/277)).
+
+
+The candidate for file system operations to be included in stdlib is being developed by
+[@MarDiehl](https://github.com/MarDiehl) and [@arjenmarkus](https://github.com/arjenmarkus)
+in [this repository](https://github.com/MarDiehl/stdlib_os).
+Please try it out and let us know how it works, if there are any issues, or if the API can be improved.
+
+## Fortran Package Manager
+
+Here's what's new in `fpm`:
+
+* [#342](https://github.com/fortran-lang/fpm/pull/342):
+  Fix broken link in contributing guidelines
+* [#337](https://github.com/fortran-lang/fpm/pull/337):
+  Allow hyphens in fpm project names in "fpm new"
+* [#335](https://github.com/fortran-lang/fpm/pull/335):
+  Fix: performance regression
+* [#334](https://github.com/fortran-lang/fpm/pull/334):
+  Remove a name clash in the fpm testsuite
+
+Work in progress:
+
+* [First beta release](https://github.com/fortran-lang/fpm/milestone/1) (WIP):
+  First feature-complete release of the Fortran implementation.
+* [#230](https://github.com/fortran-lang/fpm/pull/230),
+  [#261](https://github.com/fortran-lang/fpm/pull/261) (WIP):
+  Specification of the fpm CLI.
+* [#316](https://github.com/fortran-lang/fpm/pull/316) (WIP):
+  Update subcommand "new" to reflect the addition of support for examples
+* [#345](https://github.com/fortran-lang/fpm/pull/345) (WIP):
+  Update: fpm\_backend with dynamic openmp scheduling
+
+`fpm` is still in early development and we need as much help as we can get.
+Here's how you can help today:
+
+* Use it and let us know what you think! Read the [fpm packaging guide](https://github.com/fortran-lang/fpm/blob/master/PACKAGING.md) to learn how to build your package with fpm, and the [manifest reference](https://github.com/fortran-lang/fpm/blob/master/manifest-reference.md) to learn what are all the things that you can specify in the fpm.toml file.
+* Browse existing *fpm* packages on the [fortran-lang website](https://fortran-lang.org/packages/fpm)
+* Browse the [open issues](https://github.com/fortran-lang/fpm/issues) and see if you can help implement any fixes or features.
+* Adapt your Fortran package for fpm and submit it to the [Registry](https://github.com/fortran-lang/fpm-registry).
+* Improve the documentation.
+
+The short-term goal of fpm is to make development and installation of Fortran packages with dependencies easier.
+Its long term goal is to build a rich and decentralized ecosystem of Fortran packages and create a healthy
+environment in which new open source Fortran projects are created and published with ease.
+
+## Compilers
+
+### Classic Flang
+
+TODO
+
+### LLVM Flang
+
+TODO
+
+Call notes will be sent to the _flang-dev_ email list and also recorded [here]( https://docs.google.com/document/d/10T-S2J3GrahpG4Ooif93NSTz2zBW0MQc_RlwHi0-afY).
+
+
+## Events
+
+* We had our 8th Fortran Monthly call on January 19.
+You can watch the recording below:
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/QfiBUAgI3kw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+As usual, subscribe to the [mailing list](https://groups.io/g/fortran-lang) and/or
+join the [Discourse](https://fortran-lang.discourse.group) to stay tuned with the future meetings.
+
+## Contributors
+
+We thank everybody who contributed to fortran-lang in the past month by
+commenting in any of these repositories:
+
+* [fortran-lang/stdlib](https://github.com/fortran-lang/stdlib)
+* [fortran-lang/stdlib-cmake-example](https://github.com/fortran-lang/stdlib-cmake-example)
+* [fortran-lang/fpm](https://github.com/fortran-lang/fpm)
+* [fortran-lang/fpm-registry](https://github.com/fortran-lang/fpm-registry)
+* [fortran-lang/setup-fpm](https://github.com/fortran-lang/setup-fpm)
+* [fortran-lang/fortran-lang.org](https://github.com/fortran-lang/fortran-lang.org)
+* [fortran-lang/benchmarks](https://github.com/fortran-lang/benchmarks)
+* [j3-fortran/fortran\_proposals](https://github.com/j3-fortran/fortran_proposals)
+
+<div id="gh-contributors" data-startdate="January 01 2021" data-enddate="January 31 2021" height="500px"></div>


### PR DESCRIPTION
I put together a draft for the February monthly newsletter and populated it from the repository activities.

- [x] collect PRs from stdlib
- [x] collect PRs from fpm, setup-fpm and fpm-registry
- [x] collect PRs from fortran-lang.org
- [x] add link to Fortran monthly call recording
- [ ] update contributor data (@LKedward)
- [ ] add updates on classic flang
- [ ] add updates on LLVM flang
- [ ] add updates on LFortran (@certik)

Please review and edit if needed. As usual, please add your name to the authors list if you add, edit, or review content.