### PR TITLE
Fix broken link for LLVM flang

### DIFF
--- a/compilers.md
+++ b/compilers.md
@@ -20,7 +20,7 @@ with gfortran.
 
 ### LLVM Flang
 
-[Flang](https://github.com/llvm/llvm-project/tree/master/flang)
+[Flang](https://github.com/llvm/llvm-project/tree/main/flang)
 is a new front-end for Fortran 2018 that has been recently
 added to LLVM.
 It is implemented in modern C++ and uses a Fortran-oriented MLIR dialect for lowering to LLVM IR.


### PR DESCRIPTION
- LLVM renamed their default branch from master to main

Fixes #198 