### PR TITLE
Add more electronic structure and atomistic simulation packages

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -530,6 +530,12 @@
   tags:
   version: none
 
+- name: Illustrate
+  github: ccsb-scripps/illustrate
+  description: Biomolecular Illustration Tool
+  categories: graphics
+  tags: pdb
+
 # --- Numerical libraries ---
 
 - name: OpenBLAS
@@ -1009,6 +1015,47 @@
   categories: scientific
   tags: quantum-chemistry computational-chemistry atomistic-simulations
   license: LGPL-3.0-or-later
+
+- name: eT
+  gitlab: eT-program/eT
+  description: electronic structure program with coupled cluster, multiscale and multilevel methods
+  categories: scientific
+  tags: electronic-structure coupled-cluster
+
+- name: tinker
+  github: TinkerTools/tinker
+  description: Software Tools for Molecular Design
+  categories: scientific
+  tags: molecular-modeling
+  license: custom
+  version: none
+
+- name: siesta
+  gitlab: siesta-project/siesta
+  description: A first-principles materials simulation code using DFT
+  categories: scientific
+  tags: electronic-structure density-functional-theory
+
+- name: Dalton
+  gitlab: dalton/dalton
+  description: Powerful molecular electronic structure program
+  categories: scientific
+  tags: electronic-structure relativistic
+  license: LGPL-2.1
+
+- name: LSDalton
+  gitlab: dalton/lsdalton
+  description: Linear scaling molecular electronic structure program
+  categories: scientific
+  tags: electronic-structure relativistic
+  license: LGPL-2.1
+
+- name: BigDFT
+  gitlab: l_sim/bigdft-suite
+  description: fast, precise, and flexible DFT code for ab-initio atomistic simulation
+  categories: scientific
+  tags: electronic-structure wavelets density-functional-theory
+  license: custom
 
 # --- Examples / demos / templates ---
 


### PR DESCRIPTION
Add packages suggested in https://fortran-lang.discourse.group/t/some-fortran-related-sites-and-packages/712

- [Illustrate](https://github.com/ccsb-scripps/illustrate)
- [Tinker](https://github.com/TinkerTools/tinker) (no open-source license)
- [eT](https://gitlab.com/eT-program/eT)
- [Siesta](https://gitlab.com/siesta-project/siesta)
- [Dalton](https://gitlab.com/dalton/dalton)
- [LSDalton](https://gitlab.com/dalton/lsdalton)
- [BigDFT](https://gitlab.com/l_sim/bigdft-suite) (no open-source license)

Only merge after #196