### PR TITLE
Added DelaunaySparse to package list

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -795,6 +795,14 @@
   tags: mpi
   license: BSD-3-Clause
 
+- name: DelaunaySparse
+  github: vtopt/DelaunaySparse
+  description: Multivariate Interpolation via a Sparse Subset of the Delaunay Triangulation in Medium to High Dimensions.
+  categories: numerical
+  tags: interpolation openmp acm-toms
+  license: MIT
+  version: none
+
 # --- Scientific codes ---
 
 - name: "DFTB+"
@@ -1166,6 +1174,7 @@
   tags: equation parser
   version: none
   license: Apache2.0
+  version: none
 
 - name: Tsunami
   github: modern-fortran/tsunami

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1174,7 +1174,6 @@
   tags: equation parser
   version: none
   license: Apache2.0
-  version: none
 
 - name: Tsunami
   github: modern-fortran/tsunami


### PR DESCRIPTION
DelaunaySparse is an open source Fortran 2003 package, recently published in ACM TOMS (Algorithm 1012) for performing piecewise linear interpolation via a sparse subset of the Delaunay mesh in high-dimensional spaces.  The publication process was subject to peer-review, not only of the paper, but also the source code, which is also published in the collected algorithms of ACM TOMS.  The code itself is open source (MIT license).  This code has been in development for almost 4 years and tested on thousands of real-world and synthetic data sets.  It is in a stable condition and in usage at several national labs and universities.  Features robust error-handling and C + Python interfaces.  Unfortunately, we do not have "5 stars" yet on Github.  Please consider including anyway.