### PR TITLE
Correct value of pi in quickstart mini-book

### DIFF
--- a/learn/quickstart/variables.md
+++ b/learn/quickstart/variables.md
@@ -69,7 +69,7 @@ __Example:__ variable assignment
 
 ```fortran
   amount = 10
-  pi = 4.141592
+  pi = 3.141592
   frequency = (1.0,-0.5)
   initial = 'A'
   isOkay = .false.


### PR DESCRIPTION
Pointed out at https://news.ycombinator.com/item?id=26452715