### PR TITLE
Add QUICK to packages

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -922,6 +922,13 @@
   categories: scientific
   tags: computational-chemistry parallel-computing electronic-structure molecular-simulations density-functional-theory hartree-fock quantum-chemistry
   license: ECL-2.0
+  
+- name: QUICK
+  github: merzlab/QUICK
+  description: A GPU-enabled ab intio quantum chemistry software package
+  categories: scientific
+  tags: computational-chemistry parallel-computing electronic-structure molecular-simulations density-functional-theory hartree-fock quantum-chemistry
+  license: MPL-2.0
 
 - name: "OFF"
   github: szaghi/OFF

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -925,7 +925,7 @@
   
 - name: QUICK
   github: merzlab/QUICK
-  description: A GPU-enabled ab intio quantum chemistry software package
+  description: A GPU-enabled ab initio quantum chemistry software package
   categories: scientific
   tags: computational-chemistry parallel-computing electronic-structure molecular-simulations density-functional-theory hartree-fock quantum-chemistry
   license: MPL-2.0


### PR DESCRIPTION
I just discovered this application, written in Fortran:

https://github.com/merzlab/QUICK

I think it should be added.