### PR TITLE
Add convert_FORTRAN_case formatter to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -328,7 +328,7 @@
   
 - name: convert_FORTRAN_case
   github:  dav05/convert_FORTRAN_case
-  description: case conversion of files writen in fixed form fortran
+  description: Case conversion of files written in fixed form Fortran
   categories: programming
   tags: formatter converter
   license: GPL-3.0  

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -325,6 +325,13 @@
   tags: interface-generator python
   license: GPL-3.0
   version: none
+  
+- name: convert_FORTRAN_case
+  github:  dav05/convert_FORTRAN_case
+  description: case conversion of files writen in fixed form fortran
+  categories: programming
+  tags: formatter converter
+  license: GPL-3.0  
 
 # --- Data types ---
 

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -331,7 +331,7 @@
   description: Case conversion of files written in fixed form Fortran
   categories: programming
   tags: formatter converter
-  license: GPL-3.0  
+  version: none  
 
 # --- Data types ---
 


### PR DESCRIPTION
Dear friends, I wrote this utility :
python3 scrip for case conversion of source code files written in fixed form FORTRAN. Ignores comments, strings, escape, sequences within strings and some special words.

I created it essentially to use in my company, but during my personal time, so it's fully tested and I'm releasing as open source. I know it does not have the 3 git starts, as I just released the code, however is really easy to verify that works very well. So I hope you can embrace this contribution to the community. 
Many thanks.
David