### PR TITLE
Add crest program to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1111,6 +1111,13 @@
   tags: quantum-chemistry computational-chemistry atomistic-simulations
   license: LGPL-3.0-or-later
 
+- name: crest
+  github: grimme-lab/crest
+  description: Conformer-rotamer ensemble search tool
+  categories: scientific
+  tags: computational-chemistry atomistic-simulations conformational-analysis metadynamics
+  license: GPL-3.0-or-later
+
 - name: eT
   gitlab: eT-program/eT
   description: electronic structure program with coupled cluster, multiscale and multilevel methods


### PR DESCRIPTION
This patch adds the conformer-rotamer ensemble search tool ([crest](https://github.com/grimme-lab/crest)) to the package index.

- OpenMP based task scheduler and automation tool for exploring potential energy surfaces written in Fortran
- the package supports meson, CMake and plain make as build systems
- compiles with Intel Fortran and GFortran, requires MKL
- documentation can be found here: https://xtb-docs.readthedocs.io/en/latest/crest.html

cc @pprcht