### PR TITLE
PRs script updates

### DIFF
--- a/_scripts/prs.py
+++ b/_scripts/prs.py
@@ -85,17 +85,17 @@ def main(smonth: Optional[str], token: Optional[str], skip_children: bool):
 
         print("## merged\n")
         for pr in prs.merged:
-            print(f"* [#{pr.number}]({pr.html_url}): {pr.title}")
+            print(f"* [#{pr.number}]({pr.html_url}):\n  {pr.title}")
         for child_reponame, child_prs in related_prs.items():
             for pr in child_prs.merged:
-                print(f"* [#{pr.number}]({pr.html_url}) (`{child_reponame}`): {pr.title}")
+                print(f"* [#{pr.number}]({pr.html_url}) (`{child_reponame}`):\n  {pr.title}")
 
         print("\n## WIP\n")
         for pr in prs.wip:
-            print(f"* [#{pr.number}]({pr.html_url}) (WIP): {pr.title}")
+            print(f"* [#{pr.number}]({pr.html_url}) (WIP):\n  {pr.title}")
         for child_reponame, child_prs in related_prs.items():
             for pr in child_prs.wip:
-                print(f"* [#{pr.number}]({pr.html_url}) (`{child_reponame}`; WIP): {pr.title}")
+                print(f"* [#{pr.number}]({pr.html_url}) (`{child_reponame}`; WIP):\n  {pr.title}")
 
 
 if __name__ == "__main__":

--- a/_scripts/prs.py
+++ b/_scripts/prs.py
@@ -31,8 +31,8 @@ def get_prs(
         if pr.merged:
             if t_a <= pr.merged_at < t_b:  # could check `.month` instead...
                 merged.append(pr)
-            if pr.merged_at < t_a:
-                break
+            # if pr.merged_at < t_a:
+            #     break
             
     wip = []  # WIP PRs (not merged, still open at this time)
     for pr in repo.get_pulls("open"):

--- a/_scripts/prs.py
+++ b/_scripts/prs.py
@@ -45,7 +45,8 @@ def get_prs(
             # if pr.merged_at < t_a:
             #     break
             # ^ This causes some to be missed since recently updated not equiv. to recently merged.
-            
+    merged.sort(key=lambda pr: pr.merged_at)  # earliest merged first
+
     wip = []  # WIP PRs (not merged, still open at this time)
     for pr in repo.get_pulls("open"):
         if pr.created_at < t_b: # and pr.updated_at >= t_a:


### PR DESCRIPTION
Fixes #283 

* removed attempted optimization that was causing merged PRs to be missed when a previously merged PR had another "update" after being merged
  * unfortunately, it doesn't seem to currently be possible to sort by merge date in the API request
* for now, the whole list of merged PRs is searched, which takes a few minutes
  * with progress bars if `tqdm` installed
* PR titles on new line in the generated Markdown
* sort merged PRs by merge date (earliest merged -> first in the output list)