### PR TITLE
Add Flatiron institute multipole libraries to the package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1234,7 +1234,8 @@
 - name: FMM3D
   github: flatironinstitute/FMM3D
   description: Compute N-body interactions governed by the Laplace and Helmholtz equations, to a specified precision, in three dimensions, on a multi-core shared-memory machine.
-  categories: scientific
+  categories: numerical
+  tags: fast-multipole-method
   license: Apache-2.0
 
 - name: fmm2d

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1241,7 +1241,8 @@
 - name: fmm2d
   github: flatironinstitute/fmm2d
   description: Compute N-body interactions governed by the Laplace and Helmholtz equations, to a specified precision, in two dimensions, on a multi-core shared-memory machine.
-  categories: scientific
+  categories: numerical
+  tags: fast-multipole-method
   license: Apache-2.0
 
 # --- Examples / demos / templates ---

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1231,6 +1231,18 @@
   tags: fluid-dynamics fluid-simulation computational-fluid-dynamics turbulence high-performance-computing hpc cfd
   version: none
 
+- name: FMM3D
+  github: flatironinstitute/FMM3D
+  description: Compute N-body interactions governed by the Laplace and Helmholtz equations, to a specified precision, in three dimensions, on a multi-core shared-memory machine.
+  categories: scientific
+  license: Apache-2.0
+
+- name: fmm2d
+  github: flatironinstitute/fmm2d
+  description: Compute N-body interactions governed by the Laplace and Helmholtz equations, to a specified precision, in two dimensions, on a multi-core shared-memory machine.
+  categories: scientific
+  license: Apache-2.0
+
 # --- Examples / demos / templates ---
 
 - name: Fortran 2018 examples


### PR DESCRIPTION
Thanks @Beliavsky for finding them.

* [FMM3D](https://github.com/flatironinstitute/FMM3D)
* [fmm2d](https://github.com/flatironinstitute/fmm2d)