### PR TITLE
Add arrayfire-fortran to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -209,7 +209,13 @@
   github: swig-fortran/flibcpp
   description: Fortran bindings to the C++ Standard Library
   categories: interfaces
-  tags: c++
+  tags: cpp
+
+- name: arrayfire-fortran
+  github: arrayfire/arrayfire-fortran
+  description: Fortran binding to the ArrayFire general purpose GPU library
+  categories: interfaces
+  tags: cpp gpu opencl
 
 # --- Compiler
 


### PR DESCRIPTION
Repository: https://github.com/arrayfire/arrayfire-fortran

See also https://fortran-lang.discourse.group/t/questions-from-a-fortran-hpc-webinar/1516/20