### PR TITLE
Fix insecure workflow.

### DIFF
--- a/.github/workflows/buildPRPreview.yml
+++ b/.github/workflows/buildPRPreview.yml
@@ -1,8 +1,7 @@
 # Github action to build Jekyll site for a pull request preview
-#
-#  Built site is pushed to 'gh-pages' branch
-#   under directory pr/pr_id/
-#
+# We have to checkout and run untrusted code! This is dangerous if done in a privileged context.
+# That's why this action only has read-permissions.
+# Commenting on the PR and pushing the result is done in the "commentAndPushPRPreview.yml" action.
 
 name: Jekyll PR Preview
 
@@ -10,10 +9,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions: read-all
+
 env:
   SRC_DIR: src
   PUBLISH_DIR: gh-pages
-  SITE_URL: https://fortran-lang.org
   FPM_INDEX: "https://raw.githubusercontent.com/fortran-lang/fpm-registry/master/index.json"
 
 jobs:
@@ -22,11 +22,16 @@ jobs:
     if: github.event.issue.pull_request && contains(github.event.comment.body,'#build_preview')
     
     steps:
+    
+    # Checkout repo into SRC_DIR
+    - name: Checkout pr/${{github.event.issue.number}}
+      uses: actions/checkout@v2
+      with:
+        path: ${{env.SRC_DIR}}
 
     # Checkout PR branch into SRC_DIR
-    - name: Checkout pr/${{github.event.issue.number}}
-      run: | 
-        git clone https://github.com/${{github.repository}} ${{env.SRC_DIR}}
+    - name: Fetch pr/${{github.event.issue.number}}
+      run: |
         cd ${{env.SRC_DIR}}
         git fetch origin pull/${{github.event.issue.number}}/head:pr-${{github.event.issue.number}}
         git checkout pr-${{github.event.issue.number}}
@@ -78,21 +83,19 @@ jobs:
         bundle exec jekyll build --future -d _site/${BUILD_DIR}
         cp -r _site/* ../${{env.PUBLISH_DIR}}/
         touch ../${{env.PUBLISH_DIR}}/.nojekyll
-
-    # Commit and push changes to remote/gh-pages
-    - name: Commit and push to gh-pages
-      uses: EndBug/add-and-commit@v4.4.0
+    - name: Upload jekyll site as artifact
+      uses: actions/upload-artifact@v2
       with:
-        cwd: ${{env.PUBLISH_DIR}}
-        message: "Jekyll build, preview ${{env.BUILD_DIR}} (on:pull_request)"
-        ref: 'gh-pages'
-      env:  
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # Comment on pull request 
-    - name: Comment on pull request
-      uses: peter-evans/create-or-update-comment@v1
+        name: jekyllSite
+        path: |
+          ${{env.PUBLISH_DIR}}/${{env.BUILD_DIR}}
+    - name: Save PR number and BUILD_DIR
+      run: |
+          mkdir -p ./pr
+          echo ${{env.BUILD_DIR}} > ./pr/BUILD_DIR
+          echo ${{github.event.issue.number}} > ./pr/NR
+    - uses: actions/upload-artifact@v2
       with:
-        issue-number: ${{github.event.issue.number}}
-        body: "This PR has been built with Jekyll and can be previewed at: <${{env.SITE_URL}}/${{env.BUILD_DIR}}/>"
+        name: pr
+        path: pr/
 

--- a/.github/workflows/commentAndPushPRPreview.yml
+++ b/.github/workflows/commentAndPushPRPreview.yml
@@ -1,0 +1,75 @@
+name: Comment on the pull request and push the PR preview to the gh-pages branch
+
+# read-write repo token
+# access to secrets
+#
+# The PR preview of the changes is generated in the unprivileged action "buildPRPreview.yml".
+# This action takes the output and pushes it to the gh-pages branch and comments on the PR.
+# As we do not checkout/run untrusted code, this should be safe.
+
+on:
+  workflow_run:
+    workflows: ["Jekyll PR Preview"]
+    types:
+      - completed
+
+env:
+  PUBLISH_DIR: gh-pages
+  SITE_URL: https://fortran-lang.org
+  RUN_ID: ${{ github.event.workflow_run.id }}
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'issue_comment' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+        # Checkout existing gh-pages branch into PUBLISH_DIR
+      - name: Checkout gh-pages
+        uses: actions/checkout@v2
+        with:
+          path: ${{env.PUBLISH_DIR}}
+          ref: 'gh-pages' 
+          
+      - name: Get PR number and BUILD_DIR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: | 
+          gh run download -R ${{github.repository}} --name "pr" --dir "prNumberForWorkflow" "$RUN_ID" 
+          echo "UNTRUSTED_PR_NUMBER=$(cat prNumberForWorkflow/NR)" >> $GITHUB_ENV
+          echo "UNTRUSTED_BUILD_DIR=$(cat prNumberForWorkflow/BUILD_DIR)" >> $GITHUB_ENV
+        # Assume that an attacker can write arbitrary values into UNTRUSTED_PR_NUMBER and UNTRUSTED_BUILD_DIR
+          
+      - name: Download and extract jekyll site
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download -R ${{github.repository}} --name "jekyllSite" --dir "/tmp/jekyllSite" "$RUN_ID"
+          cp -a /tmp/jekyllSite/. ${PUBLISH_DIR}/${UNTRUSTED_BUILD_DIR}
+
+      # We have to make sure that an attacker can not push **new** workflow files to the gh-pages branch
+      # If the attacker could do this, he could create a pull_request_target workflow and create a PR
+      # against the gh-pages branch. The "attacker" controlled files are written to 
+      # ${PUBLISH_DIR}/${UNTRUSTED_BUILD_DIR} by the `gh run download ` above, so this might look
+      # safe - because there is the ${UNTRUSTED_BUILD_DIR} directory - but an "attacker" could easily
+      # set this variable to an empty string. And then all files would be added directly into ${PUBLISH_DIR}.
+      - name: Reject invalid files
+        run: test ! -d ${PUBLISH_DIR}/.github/workflows/ && test ! -f ${PUBLISH_DIR}/.github/CODEOWNERS
+
+      # Commit and push changes to remote/gh-pages
+      - name: Commit and push to gh-pages
+        uses: EndBug/add-and-commit@v4.4.0
+        with:
+          cwd: ${{env.PUBLISH_DIR}}
+          message: "Jekyll build, preview ${{env.UNTRUSTED_BUILD_DIR}} (on:pull_request)"
+          ref: 'gh-pages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
+               
+      # Comment on pull request 
+      - name: Comment on pull request
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{env.UNTRUSTED_PR_NUMBER}}
+          body: "This PR has been built with Jekyll and can be previewed at: <${{env.SITE_URL}}/${{env.UNTRUSTED_BUILD_DIR}}/>"


### PR DESCRIPTION
Actions triggered on "issue_comment" have access to
write permissions and repository secrets by default.
If we checkout and build untrusted code an attacker
can get access to the secrets as well. They can exe-
cute code by adding a jekyll ruby plugin in
"_plugins/malicious.rb".

To prevent this, we split the building of the site
and pushing the site to gh-pages and commenting on
the PR.

The site building is done with only read
permissions, so running untrusted code is not a
problem. If the site building finished successfully
a privileged action is triggered that then pushed
the site to the gh-pages branch and comments on the
PR.

I also added a check that prevents pushing 
".github/workflows/" files to the gh-pages branch, because
this would allow secret extraction and repository modification as well.
(If you can add new workflows files you do what every you want inside them)