### PR TITLE
Add QCxMS to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1175,12 +1175,19 @@
   tags: quantum-chemistry computational-chemistry atomistic-simulations
   license: LGPL-3.0-or-later
 
+- name: qcxms
+  github: qcxms/qcxms
+  description: Quantum mechanic mass spectrometry calculation program
+  categories: scientific
+  tags: computational-chemistry molecular-dynamics mass-spectrometry
+  license: LGPL-3.0-or-later
+
 - name: crest
   github: grimme-lab/crest
   description: Conformer-rotamer ensemble search tool
   categories: scientific
   tags: computational-chemistry atomistic-simulations conformational-analysis metadynamics
-  license: GPL-3.0-or-later
+  license: LGPL-3.0-or-later
 
 - name: eT
   gitlab: eT-program/eT


### PR DESCRIPTION
- source at [qcxms/qcxms](https://github.com/qcxms/QCxMS)
- builds with meson, supports Intel Fortran
- [documentation](https://xtb-docs.readthedocs.io/en/latest/qcxms_doc/qcxms.html)

cc @jaythedog