### PR TITLE
remove excess 'mpi' tag from fortran2018-examples

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -104,7 +104,7 @@
   description: A Modern Fortran Library for Astrodynamics
   categories: libraries
   license: BSD-3-Clause
-  
+
 - name: The NJOY Nuclear Data Processing System
   github: njoy/NJOY2016
   description: Package for producing pointwise and multigroup nuclear cross sections and related quantities from evaluated nuclear data in the ENDF format
@@ -368,13 +368,13 @@
   tags: interface-generator python
   license: GPL-3.0
   version: none
-  
+
 - name: convert_FORTRAN_case
   github:  dav05/convert_FORTRAN_case
   description: Case conversion of files written in fixed form Fortran
   categories: programming
   tags: formatter converter
-  version: none  
+  version: none
 
 # --- Data types ---
 
@@ -1028,7 +1028,7 @@
   categories: scientific
   tags: computational-chemistry parallel-computing electronic-structure molecular-simulations density-functional-theory hartree-fock quantum-chemistry
   license: ECL-2.0
-  
+
 - name: QUICK
   github: merzlab/QUICK
   description: A GPU-enabled ab initio quantum chemistry software package
@@ -1286,10 +1286,10 @@
   github: gemini3d/gemini3d
   description: 3D ionospheric model covering local (> 10 gyroradii) to global scales.
   categories: scientific
-  
+
 - name: SNaC
   github: p-costa/SNaC
-  description: A multi-block solver for massively parallel direct numerical simulations (DNS) of fluid flows 
+  description: A multi-block solver for massively parallel direct numerical simulations (DNS) of fluid flows
   categories: scientific
   tags: fluid-dynamics fluid-simulation computational-fluid-dynamics turbulence high-performance-computing hpc cfd
   version: none
@@ -1321,7 +1321,7 @@
   github: scivision/fortran2018-examples
   description: Easy examples of scientific computing with modern, powerful, easy Fortran 2018 standard
   categories: examples
-  tags: block coarray contiguous mpi namelist openmp random submodule iso_fortran_env
+  tags: block coarray contiguous namelist openmp random submodule iso_fortran_env
 
 - name: Fortran patterns
   github: farhanjk/FortranPatterns


### PR DESCRIPTION
The MPI examples were moved to another repo:
https://github.com/scivision/fortran-coarray-mpi-examples