### PR TITLE
Alternative approach to avoiding integer division

### DIFF
--- a/learn/best_practices/floating_point.md
+++ b/learn/best_practices/floating_point.md
@@ -74,12 +74,19 @@ a = 3
 ```
 
 In order to impose floating point division (as opposed to integer
-division `1/2` equal to `0`), one can convert the integer to a floating
+division `3/4` equal to `0`), one can convert the integer to a floating
 point number by:
 
 ```fortran
 real(dp) :: a
-a = real(1, dp) / 2  ! 'a' is equal to 0.5_dp
+a = real(3, dp) / 4  ! 'a' is equal to 0.75_dp
+```
+
+or simply separate the integer division with multiplication by `1.0_dp`
+
+```fortran
+real(dp) :: a
+a = 3 * 1.0_dp / 4  ! 'a' is equal to 0.75_dp
 ```
 
 To print floating point numbers without losing precision use the unlimited

--- a/learn/best_practices/integer_division.md
+++ b/learn/best_practices/integer_division.md
@@ -4,29 +4,35 @@ title: Integer Division
 permalink: /learn/best_practices/integer_division
 ---
 
-Fortran distinguishes between floating point and integer arithmetic.
-It is important to note that division for integers is always using
-integer arithmetic.
-Consider the following example for integer division of an odd number:
+Fortran distinguishes between floating point and integer arithmetic.  It is
+important to note that division for integers is always using integer
+arithmetic. Furthermore, while Fortran uses the standard order-of-operations
+(e.g. multiplication and division preceed addition and subtraction, in the
+absence of parenthesis), operations of the same precedance are evaluated from
+left to right.  Consider the following example for integer division of an odd
+number:
 
 ```fortran
 integer :: n
 n = 3
 print *, n / 2  ! prints 1
 print *, n*(n + 1)/2  ! prints 6
-print *, n/2*(n + 1)  ! prints 4
+print *, n/2*(n + 1)  ! prints 4 (left-to-right evaluation order)
 n = -3
 print *, n / 2  ! prints -1
 ```
 
 Be careful about whether you want to actually use integer arithmetic
 in this context. If you want to use floating point arithmetic instead
-make sure to cast to reals before using the division operator:
+make sure to cast to reals before using the division operator, or separate
+the integers by multiplying by `1.0_dp`:
 
 ```fortran
 integer :: n
 n = 3
 print *, real(n, dp) / 2  ! prints 1.5
+print *, n * 1.0_dp / 2  ! prints 1.5
 n = -3
 print *, real(n, dp) / 2  ! prints -1.5
+print *, n * 1.0_dp / 2  ! prints -1.5
 ```


### PR DESCRIPTION
The tutorial suggests bypassing integer division by type-casting one variable to real, i.e. to avoid `3/4 == 0`, you can do `real(3, dp) / 4`. 

While that's fine, it is often nicer to simply write `3 * 1.0_dp / 4`. This pull request updates the tutorial to note that.

In addition, the documentation now notes Fortran's default left-to-right operator precedence -- which affects one of the examples on the page about integers. 