### PR TITLE
Minor fixes in Best Practices.

### DIFF
--- a/learn/best_practices/floating_point.md
+++ b/learn/best_practices/floating_point.md
@@ -32,7 +32,7 @@ For some insightful thoughts on kind parameters see
 It is recommended to have a central module to define kind parameters and include
 them with use as necessary. An example for such a module is given with
 
-```
+```fortran
 !> Numerical storage size parameters for real and integer values
 module kind_parameter
    implicit none

--- a/learn/best_practices/modules_programs.md
+++ b/learn/best_practices/modules_programs.md
@@ -12,7 +12,7 @@ to avoid name clashes when used as dependency in other projects.
 
 An example for such a module file is given here
 
-```
+```fortran
 !> Interface to TOML processing library.
 !>
 !> ...

--- a/learn/best_practices/multidim_arrays.md
+++ b/learn/best_practices/multidim_arrays.md
@@ -56,7 +56,7 @@ three array using a matrix-vector operation:
 
 ```fortran
 subroutine matmul312(amat, bvec, cmat)
-  real(dp), contiguous, intent(in),  target :: amat(:, :, :)
+  real(dp), contiguous, intent(in), target :: amat(:, :, :)
   real(dp), intent(in) :: bvec(:)
   real(dp), contiguous, intent(out), target :: cmat(:, :)
   real(dp), pointer :: aptr(:, :)

--- a/learn/best_practices/multidim_arrays.md
+++ b/learn/best_practices/multidim_arrays.md
@@ -56,9 +56,9 @@ three array using a matrix-vector operation:
 
 ```fortran
 subroutine matmul312(amat, bvec, cmat)
-  real(dp), contiguous, intent(in) :: amat(:, :, :)
+  real(dp), contiguous, intent(in),  target :: amat(:, :, :)
   real(dp), intent(in) :: bvec(:)
-  real(dp), contiguous, intent(out) :: cmat(:, :)
+  real(dp), contiguous, intent(out), target :: cmat(:, :)
   real(dp), pointer :: aptr(:, :)
   real(dp), pointer :: cptr(:)
 


### PR DESCRIPTION
- [x] Minor fixes in Best Practices: Syntax highlighting and pointer usage (target).

#### Sorry

**I'm so sorry!** I cloned `fortran-lang.org` by mistake using `github` software and submitted this branch.
When I realized it, I found that it had been submitted, and I hope to get your forgiveness. 