### PR TITLE
Fix typo in author field

### DIFF
--- a/_posts/2021-11-01-Fortran-Newsletter-November-2021.md
+++ b/_posts/2021-11-01-Fortran-Newsletter-November-2021.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Fortran newsletter: November 2021"
 category: newsletter
-authors: Sebastian Ehlert, Alexis Perry-Holby, Milan Curcic, Ondřej Čertík
+author: Sebastian Ehlert, Alexis Perry-Holby, Milan Curcic, Ondřej Čertík
 ---
 
 Welcome to the November 2021 edition of the monthly Fortran newsletter.


### PR DESCRIPTION
There was a typo in the "author" field which caused the authors list not to be rendered in the November newsletter, as pointed out by @certik [here](https://github.com/fortran-lang/fortran-lang.org/pull/343#issuecomment-956498364).