### PR TITLE
Add MCST LCC C, C++ and Fortran compiler

### DIFF
--- a/compilers.md
+++ b/compilers.md
@@ -174,6 +174,14 @@ Silverfrost Fortran runs on Windows / x86_64. There is a free personal edition.
 conforms to the Fortran-2003 standard (ISO/IEC 1539-1:2004) and supports many
 features from Fortran-2008 (ISO/IEC 1539-1:2010).
 
+### LCC
+
+[MCST C, C++, Fortran Compiler](http://mcst.ru/lcc) with full support of Fortran-95
+(ISO/IEC 1539:1997) and partial support of Fortran-2003 (ISO/IEC 1539:2004),
+Fortran-2008 (ISO/IEC 1539:2010) and Fortran-2018 (ISO/IEC 1539:2018). Used for
+russian processor architectures Elbrus (e2k) and SPARC (MCST-R), also a cross-compiler
+for x86_64 architecture is available.
+
 ## Discontinued
 
 The following is a list of Fortran compilers that seem discontinued, so we do


### PR DESCRIPTION
Hello!

I recently started learning Fortran and I like it. In Russia we have our own proprietary processor architectures Elbrus a.k.a. e2k and SPARC a.k.a. MCST-R (licensed by Sun) developed by the MCST (Moscow Center of SPARC Technologies) company. Also, MCST has own C, C++ and Fortran proprietary compiler named LCC. I think it is worth mentioning in the list of available compilers. Unfortunately, I haven't had a chance to try it yet, since the processors are not yet available to individuals.

Thanks.