### PR TITLE
Adding Fortran Error Handler to packages index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -382,6 +382,14 @@
   categories: programming
   tags: formatter converter
   version: none
+  
+- name: fortran-error-handler
+  github: samharrison7/fortran-error-handler
+  description: Comprehensive error handling framework for Modern Fortran
+  categories: programming
+  tags: errors logging fpm
+  version: none
+  license: MIT
 
 # --- Data types ---
 

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -388,8 +388,6 @@
   description: Comprehensive error handling framework for Modern Fortran
   categories: programming
   tags: errors logging fpm
-  version: none
-  license: MIT
 
 # --- Data types ---
 


### PR DESCRIPTION
I've just made my Fortran error handling framework compatible with fpm, so I thought it would be a good time to add to the Fortran Lang package index! Pretty certain it meets all the requirements.

Here is the repo: https://github.com/samharrison7/fortran-error-handler

Required details as follows:

```yaml
- name: fortran-error-handler
  github: samharrison7/fortran-error-handler
  description: Comprehensive error handling framework for Modern Fortran
  categories: programming
  tags: errors logging fpm
  version: none
  license: MIT
```