### PR TITLE
Fix end time calculation in the PRs script

### DIFF
--- a/_posts/2022-01-01-Fortran-Newsletter-January-2022.md
+++ b/_posts/2022-01-01-Fortran-Newsletter-January-2022.md
@@ -1,0 +1,213 @@
+---
+layout: post
+title: "Fortran newsletter: January 2022"
+category: newsletter
+author: Milan Curcic
+---
+
+Happy New Year and welcome to the January 2022 edition of the monthly Fortran 
+newsletter.
+The newsletter comes out at the beginning of every month and details
+Fortran news from the previous month.
+
+<ul id="page-nav"></ul>
+
+## fortran-lang.org
+
+Here's what's new and ongoing in the fortran-lang.org repo:
+
+* [#349](https://github.com/fortran-lang/fortran-lang.org/pull/349):
+  Newsletter draft for December 2021
+* [#350](https://github.com/fortran-lang/fortran-lang.org/pull/350):
+  Updated CaNS item so that it shows the version
+* [#353](https://github.com/fortran-lang/fortran-lang.org/pull/353):
+  Add MCST LCC C, C++ and Fortran compiler
+* [#351](https://github.com/fortran-lang/fortran-lang.org/pull/351):
+  Use HEAD to reference default branch
+* [#355](https://github.com/fortran-lang/fortran-lang.org/pull/355):
+  2021 review article draft
+
+### Work in progress
+
+* [#356](https://github.com/fortran-lang/fortran-lang.org/pull/356) (WIP):
+  Adding Fortran Error Handler to packages index
+* [#347](https://github.com/fortran-lang/fortran-lang.org/pull/347) (WIP):
+  Fortran Intrinsics
+
+[Let us know](https://github.com/fortran-lang/fortran-lang.org/issues)
+if you have any suggestions for the website and its content.
+We welcome any new contributors to the website and the tutorials page in particular - see the
+[contributor guide](https://github.com/fortran-lang/fortran-lang.org/blob/HEAD/CONTRIBUTING.md)
+for how to get started.
+
+## Fortran Standard Library
+
+Here's what's new in stdlib:
+
+* [#500](https://github.com/fortran-lang/stdlib/pull/500):
+  Selection algorithms
+* [#586](https://github.com/fortran-lang/stdlib/pull/586):
+  Update of stdlib_stats.md
+* [#581](https://github.com/fortran-lang/stdlib/pull/581):
+  Add routines for saving/loading arrays in npy format
+* [#590](https://github.com/fortran-lang/stdlib/pull/590):
+  Update changelog
+* [#588](https://github.com/fortran-lang/stdlib/pull/588):
+  Error on no tests in CTest
+* [#585](https://github.com/fortran-lang/stdlib/pull/585):
+  stdlib_selection: correction of typos and addition of some checks
+* [#591](https://github.com/fortran-lang/stdlib/pull/591):
+  Fix compilation errors with makefiles due to command-line variable assignments
+* [#273](https://github.com/fortran-lang/stdlib/pull/273):
+  Probability Distribution and Statistical Functions -- Normal Distribution Module 
+* [#584](https://github.com/fortran-lang/stdlib/pull/584):
+  Replace the call to sort by select in stdlib_stats_median
+* [#593](https://github.com/fortran-lang/stdlib/pull/593):
+  Probability Distribution and Statistical Functions -- Uniform Distribution Module
+* [#594](https://github.com/fortran-lang/stdlib/pull/594):
+  Minor update to makefile installation instructions
+* [#596](https://github.com/fortran-lang/stdlib/pull/596):
+  Rename references to default branch
+* [#600](https://github.com/fortran-lang/stdlib/pull/600):
+  Fix iomsg allocation in save_npy
+* [#488](https://github.com/fortran-lang/stdlib/pull/488):
+  [stdlib_math] add `is_close` routines.
+* [#597](https://github.com/fortran-lang/stdlib/pull/597):
+  Add getline to read whole line from formatted unit
+* [#498](https://github.com/fortran-lang/stdlib/pull/498):
+  [stdlib_math] add `arg/argd/argpi`
+* [#603](https://github.com/fortran-lang/stdlib/pull/603):
+  Implement trueloc/falseloc
+* [#573](https://github.com/fortran-lang/stdlib/pull/573):
+  Revised Hash functions incorporating changes in the main Stdlib repository.
+* [#609](https://github.com/fortran-lang/stdlib/pull/609):
+  Consistent spec titles
+* [#610](https://github.com/fortran-lang/stdlib/pull/610):
+  Fixed tables in stdlib_hash_procedures.md
+* [#499](https://github.com/fortran-lang/stdlib/pull/499):
+  [stdlib_linalg] matrix property checks
+* [#613](https://github.com/fortran-lang/stdlib/pull/613):
+  Ignore hash testing binaries and logs
+
+### Work in progress
+
+* [#611](https://github.com/fortran-lang/stdlib/pull/611) (WIP):
+  Hash maps
+* [#605](https://github.com/fortran-lang/stdlib/pull/605) (WIP):
+  [stdlib_math] Add function `diff`
+* [#604](https://github.com/fortran-lang/stdlib/pull/604) (WIP):
+  Add get_argument, get_variable and set_variable
+* [#580](https://github.com/fortran-lang/stdlib/pull/580) (WIP):
+  Add terminal and color escape sequences
+* [#552](https://github.com/fortran-lang/stdlib/pull/552) (WIP):
+  fixed bug in stringlist
+* [#536](https://github.com/fortran-lang/stdlib/pull/536) (WIP):
+  Fix conversion warnings
+* [#520](https://github.com/fortran-lang/stdlib/pull/520) (WIP):
+  [stdlib_io] add `disp`(display variable values formatted).
+* [#517](https://github.com/fortran-lang/stdlib/pull/517) (WIP):
+  adding SPEC_TEMPLATE.md #504
+* [#514](https://github.com/fortran-lang/stdlib/pull/514) (WIP):
+  pop, drop & get with basic range feature for stringlist
+* [#491](https://github.com/fortran-lang/stdlib/pull/491) (WIP):
+  Stdlib linked list
+* [#473](https://github.com/fortran-lang/stdlib/pull/473) (WIP):
+  Error stop improvements
+* [#363](https://github.com/fortran-lang/stdlib/pull/363) (WIP):
+  Sorting string's characters according to their ASCII values
+* [#286](https://github.com/fortran-lang/stdlib/pull/286) (WIP):
+  Probability Distribution and Statistical Functions -- Beta Distribution Module
+* [#278](https://github.com/fortran-lang/stdlib/pull/278) (WIP):
+  Probability Distribution and Statistical Functions -- Gamma Distribution Module
+* [#276](https://github.com/fortran-lang/stdlib/pull/276) (WIP):
+  Probability Distribution and Statistical Functions -- Exponential Distribution Module
+* [#189](https://github.com/fortran-lang/stdlib/pull/189) (WIP):
+  Initial implementation of COO / CSR sparse format
+
+Please help improve stdlib by testing and [reviewing pull requests](https://github.com/fortran-lang/stdlib/issues?q=is%3Apr+is%3Aopen+label%3A%22reviewers+needed%22)!
+
+The candidate for file system operations to be included in stdlib is being developed by
+[@MarDiehl](https://github.com/MarDiehl) and [@arjenmarkus](https://github.com/arjenmarkus)
+in [this repository](https://github.com/MarDiehl/stdlib_os).
+Please try it out and let us know how it works, if there are any issues, or if the API can be improved.
+
+## Fortran Package Manager
+
+Here's what's new in fpm:
+
+* [#634](https://github.com/fortran-lang/fpm/pull/634):
+  Better extraction of the Fortran compiler from the MPI wrapper
+
+### Work in progress
+
+* [#642](https://github.com/fortran-lang/fpm/pull/642) (WIP):
+  Replace polymorphic assignment with move_alloc
+* [#630](https://github.com/fortran-lang/fpm/pull/630) (WIP):
+  just allow . on new subcommand instead of changing canonical path pro…
+* [#622](https://github.com/fortran-lang/fpm/pull/622) (WIP):
+  Cleanup the backend output
+* [#608](https://github.com/fortran-lang/fpm/pull/608) (WIP):
+  --env switch lets you specify the prefix of the compiler-related environment variables
+* [#539](https://github.com/fortran-lang/fpm/pull/539) (WIP):
+  Add parent packages into dependency tree
+* [#498](https://github.com/fortran-lang/fpm/pull/498) (WIP):
+  Compiler flags profiles
+
+`fpm` is still in early development and we need as much help as we can get.
+Here's how you can help today:
+
+* Use it and let us know what you think! Read the [fpm packaging guide](https://github.com/fortran-lang/fpm/blob/main/PACKAGING.md)
+to learn how to build your package with fpm, and the [manifest reference](https://github.com/fortran-lang/fpm/blob/main/manifest-reference.md)
+to learn what are all the things that you can specify in the fpm.toml file.
+
+* Browse existing *fpm* packages on the [fortran-lang website](https://fortran-lang.org/packages/fpm)
+* Browse the [open issues](https://github.com/fortran-lang/fpm/issues) and see if you can help implement any fixes or features.
+* Adapt your Fortran package for fpm and submit it to the [Registry](https://github.com/fortran-lang/fpm-registry).
+* Improve the documentation.
+
+The short-term goal of fpm is to make development and installation of Fortran packages with dependencies easier.
+Its long term goal is to build a rich and decentralized ecosystem of Fortran packages and create a healthy
+environment in which new open source Fortran projects are created and published with ease.
+
+## Compilers
+
+### Flang
+
+TODO @AlexisPerry
+
+### LFortran
+
+TODO @certik
+
+We are looking for new contributors. Please do not hesitate to contact us if
+you are interested. We will help you get up to speed.
+
+## Events
+
+* We had our 21st Fortran Monthly call on December 14.
+  You can watch the recording below:
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/NSvL2yrefH8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+* We also wrote a review of the Fortran-lang projects in 2021. Read it
+  [here]({{ site.baseurl }}/newsletter/2021/12/29/Fortran-lang-2021-in-review/).
+
+As usual, subscribe to the [mailing list](https://groups.io/g/fortran-lang) and/or
+join the [Discourse](https://fortran-lang.discourse.group) to stay tuned with the future meetings.
+
+## Contributors
+
+We thank everybody who contributed to fortran-lang in the past month by
+commenting in any of these repositories:
+
+* [fortran-lang/stdlib](https://github.com/fortran-lang/stdlib)
+* [fortran-lang/stdlib-cmake-example](https://github.com/fortran-lang/stdlib-cmake-example)
+* [fortran-lang/fpm](https://github.com/fortran-lang/fpm)
+* [fortran-lang/fpm-registry](https://github.com/fortran-lang/fpm-registry)
+* [fortran-lang/setup-fpm](https://github.com/fortran-lang/setup-fpm)
+* [fortran-lang/fpm-haskell](https://github.com/fortran-lang/fpm-haskell)
+* [fortran-lang/fortran-lang.org](https://github.com/fortran-lang/fortran-lang.org)
+* [fortran-lang/benchmarks](https://github.com/fortran-lang/benchmarks)
+* [fortran-lang/fortran-forum-article-template](https://github.com/fortran-lang/fortran-forum-article-template)
+* [fortran-lang/fftpack](https://github.com/fortran-lang/fftpack)
+* [j3-fortran/fortran\_proposals](https://github.com/j3-fortran/fortran_proposals)
+
+<div id="gh-contributors" data-startdate="December 01 2021" data-enddate="January 01 2022" height="500px"></div>

--- a/_scripts/prs.py
+++ b/_scripts/prs.py
@@ -3,6 +3,7 @@ Summarize PRs for fortran-lang within a certain month.
 Requires PyGithub.
 """
 import datetime
+from dateutil.relativedelta import relativedelta
 import os
 from collections import namedtuple
 from typing import Optional
@@ -62,7 +63,7 @@ def main(smonth: Optional[str], token: Optional[str], skip_children: bool):
         t_a = datetime.datetime(now.year, now.month, 1)
     else:
         t_a = datetime.datetime.strptime(smonth, "%Y-%m")
-    t_b = datetime.datetime(t_a.year, t_a.month+1, 1)
+    t_b = t_a + relativedelta(months=1)
 
     # GitHub connection
     if token is None:

--- a/community/github_stats_data/data-fortran-lang-fortran-lang.org.json
+++ b/community/github_stats_data/data-fortran-lang-fortran-lang.org.json
@@ -2,6 +2,253 @@
     "name": "fortran-lang/fortran-lang.org",
     "issues": [
         {
+            "number": 356,
+            "user": "samharrison7",
+            "date": "2021-12-31 17:25:14+00:00",
+            "title": "Adding Fortran Error Handler to packages index",
+            "text": "I've just made my Fortran error handling framework compatible with fpm, so I thought it would be a good time to add to the Fortran Lang package index! Pretty certain it meets all the requirements.\nHere is the repo: https://github.com/samharrison7/fortran-error-handler\nRequired details as follows:\n- name: fortran-error-handler\n  github: samharrison7/fortran-error-handler\n  description: Comprehensive error handling framework for Modern Fortran\n  categories: programming\n  tags: errors logging fpm\n  version: none\n  license: MIT",
+            "comments": []
+        },
+        {
+            "number": 355,
+            "user": "milancurcic",
+            "date": "2021-12-24 01:54:32+00:00",
+            "title": "2021 review article draft",
+            "text": "This PR introduces the draft of the 2021 Fortran-lang review article.\nI think it's mostly complete. I will likely be making small edits over the next few days. But I may have missed something. If you notice something is missing and should be added, please add it. If you add new content, please commit directly to this PR. if you edit existing content, please submit a commit suggestion via GitHub.\nAnybody is welcome to contribute. If you review, edit, or add anything, please also add your name to the list of authors.\nIf possible and if there are no objections, let's please aim to merge and publish on Wednesday, December 29.\nThank you!",
+            "comments": [
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-24 01:55:06+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-24 01:56:39+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/355/"
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-24 02:00:30+00:00",
+                    "text": "The images don't seem to show up in the preview, but they do in my local build. I wonder if that's expected."
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-24 18:32:01+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-24 18:33:51+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/355/"
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-29 16:10:27+00:00",
+                    "text": "Thanks a lot, @certik, these are great. I will have a few copy edits and suggestions."
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-29 16:43:35+00:00",
+                    "text": "Thanks for improving the wording. Looks good so far."
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-29 18:44:28+00:00",
+                    "text": "Thank you all for the great additions and fixes--I'll go ahead and merge."
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-29 19:47:23+00:00",
+                    "text": "It looks great now, thanks @milancurcic for the improvements and thank you and everybody for writing this up!"
+                },
+                {
+                    "user": "jvdp1",
+                    "date": "2021-12-30 18:31:28+00:00",
+                    "text": "I was away a few days. Thank you @milancurcic and all of you for this nice review of 2021!"
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-30 19:06:05+00:00",
+                    "text": "So this wraps up 2021. Very good year for Fortran. Thank you all!\nNow, what should be our goals for 2022? Let's write down realistic goals that we should try to achieve."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-30 21:21:45+00:00",
+                    "text": "Now, what should be our goals for 2022? Let's write down realistic goals that we should try to achieve.\n\nLet's discuss on discourse (https://fortran-lang.discourse.group/t/2465), conversations on closed issues/prs are always hard to find."
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-30 21:41:47+00:00",
+                    "text": "Sure. I created a dedicated thread for that: https://fortran-lang.discourse.group/t/fortran-goals-for-2022/2473"
+                }
+            ]
+        },
+        {
+            "number": 354,
+            "user": "jvdp1",
+            "date": "2021-12-18 18:33:03+00:00",
+            "title": "FOSDEM 2022",
+            "text": "FOSDEM 2022 will be virtual again.\nAny interest to present some fortran-lang projects there? The deadline for submitting abstracts is quite close (end Dec.).",
+            "comments": [
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-19 18:04:06+00:00",
+                    "text": "Maybe post on discourse for a broader audience. I think stdlib has been moving quite a bit since FortranCon, also I'm done for a while with presenting fpm at conferences ;)."
+                },
+                {
+                    "user": "jvdp1",
+                    "date": "2021-12-20 19:58:24+00:00",
+                    "text": "Maybe post on discourse for a broader audience. I think stdlib has been moving quite a bit since FortranCon, also I'm done for a while with presenting fpm at conferences ;).\n\nUndersood ;)\nI will mention it on Discourse, at least to announce it.  Unfortunately I don't have time right now for stdlib."
+                }
+            ]
+        },
+        {
+            "number": 353,
+            "user": "dvz0",
+            "date": "2021-12-17 12:51:53+00:00",
+            "title": "Add MCST LCC C, C++ and Fortran compiler",
+            "text": "Hello!\nI recently started learning Fortran and I like it. In Russia we have our own proprietary processor architectures Elbrus a.k.a. e2k and SPARC a.k.a. MCST-R (licensed by Sun) developed by the MCST (Moscow Center of SPARC Technologies) company. Also, MCST has own C, C++ and Fortran proprietary compiler named LCC. I think it is worth mentioning in the list of available compilers. Unfortunately, I haven't had a chance to try it yet, since the processors are not yet available to individuals.\nThanks.",
+            "comments": [
+                {
+                    "user": "ivan-pi",
+                    "date": "2021-12-17 13:04:16+00:00",
+                    "text": "Would have never known. Thanks for the contribution. Here's the auto-translated text from the homepage, in case any reviewers want to add something:\n\nThe proprietary compiler of MCST JSC, the developer of the Elbrus architecture. Supports programming languages \u200b\u200bC, C ++, Fortran. It is largely compatible with the GCC (GNU Compiler Collection) compiler, both in terms of launch parameters and GNU language extensions. It has advanced tools for optimizing the generated machine code, allowing you to choose between the speed of the program and its size, as well as the compilation time.\nProduced for computers of Elbrus and SPARC architecture (MCST-R). Supplied as part of the Elbrus Programming System - standardly together with the operating system or or separately, under a supply agreement.\nA cross-compiler is a version of the compiler that functions on computers of x86-64 architecture and at the same time outputs the machine code of the Elbrus or SPARC architecture. You can get a cross-compiler upon request to  the support service if you have a license to use a conventional compiler (programming system) - for this you need to provide the model of the computer (processor), the name and version number of the target operating system. For convenience, together with the cross-compiler, an archive of files of the preinstalled Elbrus Linux system can be provided, if it is the target system for building programs."
+                }
+            ]
+        },
+        {
+            "number": 352,
+            "user": "Beliavsky",
+            "date": "2021-12-16 19:28:14+00:00",
+            "title": "Twitter feed on the site -- watch the language",
+            "text": "Looking at the tweets displayed on the site, I currently see the one below. It's ok for Twitter, but given the language, I think it makes the fortran-lang site seem less serious and professional. Is it possible to only display tweets on the site that pass a language filter? If not, the people behind @fortranlang should considering more judicious about what is retweeted.\nI hope I don't sound too stuffy. The tweet and thread were funny and harmless, but I don't they match the tone of the web site.\nFortran Retweeted\nDr. H\u00e9lo\u00efse Stevance \ud83d\udda4\u2728\n@Sydonahi\nHoly fuck Fortran is fast but I didn't know HOW fast.\nGenerated 1 million values in 4 nested for loops (do loops), thought it'd take a couple minutes.. DID IT UNDER 2 SECONDS WTF",
+            "comments": [
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-17 00:49:49+00:00",
+                    "text": "I agree, we shouldn't have such language on the site.\nBefore retweeting, I had a pause for the same reason. I decided that the potential pros outweighed the potential cons, so I did it. I forgot that we also show the feed on the landing page, which is problematic in a situation like this.\nGoing forward, we can agree to simply not RT any such language, even of it may be beneficial (e.g. this RT brought us ~20 new followers).\nOr, we can remove the feed from the site, and only provide a link to the Twitter feed."
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-17 02:34:08+00:00",
+                    "text": "I fixed this by retweeting some nice tweet, so now I see this:\n\nSo that should work.\nYes, I am not happy with the quality of interactions at Twitter in general, but it is the most effective social media right now, so I think it can bring us some good new users. I know it did. I don't know why this particular tweet generated such attention, but it did. So maybe next time we can retweet, and then retweet some other tweets, so that it is not the top 2 tweets, and then it does not appear at the front page."
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-17 03:06:59+00:00",
+                    "text": "I don't know why this particular tweet generated such attention, but it did.\n\nI think because the account has 22.7k followers. It's powerful."
+                },
+                {
+                    "user": "ivan-pi",
+                    "date": "2021-12-17 12:52:24+00:00",
+                    "text": "The person behind the tweet (@HeloiseS) is a computational astronomer.\nAmusingly, many of the responses to her tweet use the uppercase form FORTRAN, and even some examples of implicit typing. Goes to show how deeply entrenched these obsolescent forms are... Immediately after comes a backlash of responses citing equivalent or better performance with Python + Numba, or Julia.\nOverall, I agree not to retweet in case of vulgar language, but think we've learned a valuable lesson from this tweet. Personally, I like the Twitter feed on the front page. I'm not an active Twitter user but I enjoy seeing some of the tweets."
+                },
+                {
+                    "user": "HeloiseS",
+                    "date": "2021-12-17 18:12:01+00:00",
+                    "text": "Hello everybody!\nSince I'm the original poster I thought I'd add my 2cent, especially regarding certain types of language on twitter and other platforms and why that tweet got so much traction on social media.\nTwitter interactions are powerful because they walk a weird line between profession and personal content. Being informal and personable in a tweet is likely to drive interactions; using emotive language to share excitement (in this case) is an unconscious queue for others to join you in something they find exciting, whether it be how fotran is really cool or how numba can be faster in certain cases. It's called social media for a reason.\nI understand some people don't use certain types of language, and what you choose to display on your cite is your prerogative (the solution of quickly RT a couple other tweets is a smart one), but I do want to bring up the fact that casual swearing is less to do with professionalism and more to do with cultural norms in terms of geography, nationality and, to some extent, generation and class. Overall, blanket rules against swearing are rarely helpful and often at the disservice of minority groups (although it may not be the intention) - besides, one can be plenty disrespectful without 4-letter words. Maybe ensuring that the message reflects a spirit of congeniality is a better focus.\nFinal point, as someone who does know a fair bit about social media, I wouldn't recommend trying to seem too formal. Fortran's image isn't exactly that of silly goofy tool - if anything the very dry and stoic image might be limiting the interest you'll get from young millennials and gen z who have a different experience of how brands represent themselves (check the duo lingo or Ryanair Tik tok accounts) and expect a more personable, less serious approach. As for the older folks? I think it's safe to say they won't stop using Fortran if you start tweeting memes some day ;)\nHope this could bring some new perspectives."
+                },
+                {
+                    "user": "Beliavsky",
+                    "date": "2021-12-17 18:13:58+00:00",
+                    "text": "On the general subject of Twitter, I follow @SciPyTip , which has 131.4K Followers (including me) and which provides tips such as\n\"np.ones() returns an array of specified shape filled with 1's. np.zeros() does the same but filled with 0's.\"\nI guess falling attention spans have created demand for information in small quantities. Motivated by this, I just created @Fortrantip on Twitter and tweeted some very basic things such as Hello World program and a demonstration of a do loop."
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-17 18:33:39+00:00",
+                    "text": "Thanks a lot for writing here, @HeloiseS, and good points which I agree with.\nYour tweet was obviously not meant as disrespectful (and that's why I chose to RT it), though I see how a word can be offensive to some regardless of the context. We can't possibly make everybody happy all the time, but we do our best and continuously learn and adjust course to make most people happy most of the time. Though I don't like blanket rules, they may help with nuanced situations and avoiding to spend time on discussing whether something is appropriate or not. If not the best solution, avoiding such language for us may be the easiest solution for now.\nRe: formality and dryness that is pervasive in Fortran, I actively work to change this image and to make it attractive to younger audiences. It's possible to brand something dry, formal, and standard like Fortran as something that's also fun and playful."
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-17 22:55:19+00:00",
+                    "text": "Thanks for your feedback @HeloiseS, we appreciate it. I think none of us are offended by swear words. It's more of what kind of an image we want to show, and we've been figuring it out as we go. How to best handle a tweet like yours was new to us. :)\nAnyway, thanks for tweeting about Fortran! And if you have any questions, definitely let us know."
+                },
+                {
+                    "user": "HeloiseS",
+                    "date": "2021-12-17 23:24:06+00:00",
+                    "text": "I guess falling attention spans have created demand for information in small quantities. Motivated by this, I just created @Fortrantip on Twitter and tweeted some very basic things such as Hello World program and a demonstration of a do loop.\n\nThat is a great idea, and the real issue here isn't falling attention span, it's the exponential increase in content that people can choose from. People's attention is the most valuable currency on the internet and you are competing with thousands or millions of other content creators, which is why short snappy content like that scipy example work well.\nI'll follow that new Fortran account and tag you when I stumble upon tips and tricks I share on my platform :)\nEdit: @Beliavsky I recommend adding a profile picture, a banner and a slightly more extended description to make the account look legit :)"
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-19 23:17:59+00:00",
+                    "text": "Edit: @Beliavsky I recommend adding a profile picture, a banner and a slightly more extended description to make the account look legit :)\n\n@Beliavsky, I saw that you added the same logo as we use for the main Fortran account. I got confused as I mainly look at the logo and I thought it was the main Fortran account tweeting it. Do you think you could please modify the logo? You can perhaps add \"t\" to the F, or \"tip\" or some icon or something to make it distinct enough."
+                },
+                {
+                    "user": "LKedward",
+                    "date": "2021-12-20 10:08:41+00:00",
+                    "text": "I got confused as I mainly look at the logo and I thought it was the main Fortran account tweeting it.\n\nThe same thing happened to me, I thought it was from the Fortran-lang account!\nI agree it would be really good if the profile pic could be changed - perhaps even just a simple recoloring of the logo background?"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-20 11:08:06+00:00",
+                    "text": "We still need to establish some guidelines for the usage of the logo and assorted assets (see #342). I don't see an issue with using or adapting the logo or its color for Fortran related projects, but we should give some guidance on this. While I don't see a big issue with using the same logo, I think we should encourage some creative difference.\n@Beliavsky I can offer some help with designing an avatar for the FortranTip account, feel free to email or PM me via Discourse and we can create something fitting. I'm really looking forward to establish the fpm color palette around Fortran ;)."
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-20 15:22:39+00:00",
+                    "text": "I agree and also recommend changing the @FortranTip logo. If your intent is to communicate that the account is related to but different from @fortranlang, then I think changing the background color as @LKedward suggested is best. I suggest some soft (pastel) color, pick any that you like best. Adding \"tip\" to the logo as @certik suggested would be great, but may be difficult in practice considering the circular shape of Twitter profile pics.\nEdit: I just noticed Sebastian's recommended colors here. I like all of them. One of them could be a good choice for @FortranTip."
+                },
+                {
+                    "user": "Beliavsky",
+                    "date": "2021-12-20 16:15:06+00:00",
+                    "text": "I understand the need to avoid confusion with the fortranlang twitter and have changed the logo to what @milancurcic linked to: small Fs of various colors. Is that ok?"
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-20 16:29:03+00:00",
+                    "text": "@Beliavsky, interesting. It's not what I had in mind (I thought just having a single F, but with a different color), but now that I see this, I kinda like it. Definitely distinct from the @fortranlang logo."
+                }
+            ]
+        },
+        {
+            "number": 351,
+            "user": "awvwgk",
+            "date": "2021-12-12 18:56:49+00:00",
+            "title": "Use HEAD to reference default branch",
+            "text": "reference HEAD commit instead of branch name",
+            "comments": [
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-24 18:24:48+00:00",
+                    "text": "I just noticed this--thank you!"
+                }
+            ]
+        },
+        {
+            "number": 350,
+            "user": "p-costa",
+            "date": "2021-12-07 23:18:21+00:00",
+            "title": "Updated CaNS item so that it shows the version",
+            "text": "None",
+            "comments": [
+                {
+                    "user": "p-costa",
+                    "date": "2021-12-07 23:18:37+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-07 23:20:23+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/350/"
+                },
+                {
+                    "user": "p-costa",
+                    "date": "2021-12-07 23:22:04+00:00",
+                    "text": "looks good :) #delete_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-07 23:22:45+00:00",
+                    "text": "The preview build for this PR has now been deleted."
+                },
+                {
+                    "user": "p-costa",
+                    "date": "2021-12-09 15:58:12+00:00",
+                    "text": "It's a pedantic change, but could anyone approve it? E.g., @certik @milancurcic @awvwgk?\nThanks! :)"
+                }
+            ]
+        },
+        {
             "number": 349,
             "user": "milancurcic",
             "date": "2021-11-27 18:20:59+00:00",
@@ -12,6 +259,31 @@
                     "user": "AlexisPerry",
                     "date": "2021-11-29 18:13:43+00:00",
                     "text": "PR created for Flang updates: milancurcic#2"
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-01 07:11:15+00:00",
+                    "text": "I don't have the time to write it up for LFortran. If anybody has time to help, I would appreciate it. If not, then let's skip this month."
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-01 15:17:43+00:00",
+                    "text": "No problem, I should be able to write it up this afternoon."
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-01 17:17:34+00:00",
+                    "text": "@certik see 64e5950. I only summarized user-facing changes for brevity. I think this newsletter is ready to go."
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-01 21:12:30+00:00",
+                    "text": "I'll go ahead and merge. Thank you all!"
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-01 21:56:18+00:00",
+                    "text": "@milancurcic thanks Milan! I really appreciate it. It looks great."
                 }
             ]
         },
@@ -130,6 +402,336 @@
                     "user": "certik",
                     "date": "2021-11-27 04:33:04+00:00",
                     "text": "I have good experience with Hugo. Very fast builds."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-01 21:44:54+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-01 21:49:47+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-02 00:09:14+00:00",
+                    "text": "Unfortunately a long ways to go, and I want to add basic statements as well  (EXIT, STOP, ALLOCATE ....) and link to other resources. Did not seem to get much interest on Fortran Discourse either.  Waiting for a response from ISO committee on permission to use excerpts from the standard. Hope that does not backfire."
+                },
+                {
+                    "user": "certik",
+                    "date": "2021-12-02 00:30:00+00:00",
+                    "text": "@urbanjost I thought you got great response. We all want this!"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-02 02:12:28+00:00",
+                    "text": "I was looking more for feedback from others that might want to contribute and was looking to use that to make an easier way (probably allowing for plain text contributions) as there are quite a few requirements for contributing directly to the PR that I thought might be off-putting.    As a lot of Fortran developers are largely self-taught and there are less freely available resources available (at least historically, it is getting better) I think starting with expanded descriptions of the intrinsics will be useful, but is going to be slow going if only a few people contribute; and I honestly have yet to use the atomic procedures although I am familiar with them. Coming up with some good examples for some of the routines like that is going to be time-consuming.\nWhen I build this on my machine all the links work, but when using the build on the pull request the automatically built alphabetical links work, but the ones in the body of the index do not.  Do those work for anyone?"
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-02 03:01:39+00:00",
+                    "text": "When I build this on my machine all the links work, but when using the build on the pull request the automatically built alphabetical links work, but the ones in the body of the index do not. Do those work for anyone?\n\nSame here, they work in my local build."
+                },
+                {
+                    "user": "arjenmarkus",
+                    "date": "2021-12-02 10:44:21+00:00",
+                    "text": "I'd love to help out with this, but I am not sure how I can contribute ;).\n\nI just checked the built tutorial and found that you can nicely scroll in\nthe list and view the various items, but when you do click on one, the list\nimmediately scrolls to the beginning. Not enitirely what I expected.\n\nOp do 2 dec. 2021 om 03:12 schreef urbanjost ***@***.***>:\n\u2026\n I was looking more for feedback from others that might want to contribute\n and was looking to use that to make an easier way (probably allowing for\n plain text contributions) as there are quite a few requirements for\n contributing directly to the PR that I thought might be off-putting. As a\n lot of Fortran developers are largely self-taught and there are less freely\n available resources available (at least historically, it is getting better)\n I think starting with expanded descriptions of the intrinsics will be\n useful, but is going to be slow going if only a few people contribute; and\n I honestly have yet to use the atomic procedures although I am familiar\n with them. Coming up with some good examples for some of the routines like\n that is going to be time-consuming.\n\n When I build this on my machine all the links work, but when using the\n build on the pull request the automatically built alphabetical links work,\n but the ones in the body of the index do not. Do those work for anyone?\n\n \u2014\n You are receiving this because you are subscribed to this thread.\n Reply to this email directly, view it on GitHub\n <#347 (comment)>,\n or unsubscribe\n <https://github.com/notifications/unsubscribe-auth/AAN6YR6QWV74FHOEYISQB63UO3IZPANCNFSM5IU5ASOA>\n .\n Triage notifications on the go with GitHub Mobile for iOS\n <https://apps.apple.com/app/apple-store/id1477376905?ct=notification-email&mt=8&pt=524675>\n or Android\n <https://play.google.com/store/apps/details?id=com.github.android&referrer=utm_campaign%3Dnotification-email%26utm_medium%3Demail%26utm_source%3Dgithub>."
+                },
+                {
+                    "user": "arjenmarkus",
+                    "date": "2021-12-02 10:54:45+00:00",
+                    "text": "Also note: a number of entries are doubled - acosh, co_min, get_command,\nibclr, log_gamma, (after not an empty entry), rank, selected_int_kind\n\nOp do 2 dec. 2021 om 11:44 schreef Arjen Markus ***@***.***>:\n\u2026\n I'd love to help out with this, but I am not sure how I can contribute ;).\n\n I just checked the built tutorial and found that you can nicely scroll in\n the list and view the various items, but when you do click on one, the list\n immediately scrolls to the beginning. Not enitirely what I expected.\n\n Op do 2 dec. 2021 om 03:12 schreef urbanjost ***@***.***>:\n\n> I was looking more for feedback from others that might want to contribute\n> and was looking to use that to make an easier way (probably allowing for\n> plain text contributions) as there are quite a few requirements for\n> contributing directly to the PR that I thought might be off-putting. As a\n> lot of Fortran developers are largely self-taught and there are less freely\n> available resources available (at least historically, it is getting better)\n> I think starting with expanded descriptions of the intrinsics will be\n> useful, but is going to be slow going if only a few people contribute; and\n> I honestly have yet to use the atomic procedures although I am familiar\n> with them. Coming up with some good examples for some of the routines like\n> that is going to be time-consuming.\n>\n> When I build this on my machine all the links work, but when using the\n> build on the pull request the automatically built alphabetical links work,\n> but the ones in the body of the index do not. Do those work for anyone?\n>\n> \u2014\n> You are receiving this because you are subscribed to this thread.\n> Reply to this email directly, view it on GitHub\n> <#347 (comment)>,\n> or unsubscribe\n> <https://github.com/notifications/unsubscribe-auth/AAN6YR6QWV74FHOEYISQB63UO3IZPANCNFSM5IU5ASOA>\n> .\n> Triage notifications on the go with GitHub Mobile for iOS\n> <https://apps.apple.com/app/apple-store/id1477376905?ct=notification-email&mt=8&pt=524675>\n> or Android\n> <https://play.google.com/store/apps/details?id=com.github.android&referrer=utm_campaign%3Dnotification-email%26utm_medium%3Demail%26utm_source%3Dgithub>.\n>\n>"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-02 14:44:41+00:00",
+                    "text": "Ends up if you make any typo at all the index repeats the last value it did get, I guess. And apparently the title \"null\" is a reserved word.  It has not been rebuilt and tried but I think the duplicates are all gone now; but had to stick a space in \"null\" for the time being; tried decimal codes and that did not help. So that already helped.\nSo the index is automatically built so I do not have a lot of control over it that I know of; the RHS index is written by hand but the links seem to work fine on my local machine but do not work on fortran lang; so I stuck several variants of the URL for the MERGE function in so the next time it gets built I can see if any of them work.\nNew to the MINIBOOK format and how to build it locally myself; basically just followed the site download directions on the github site so not sure what the optimal way is for everyone to contribute that way;  but just plain-text or markdown versions of any of the intrinsics, especially foir the ones marked with the GNU license in the index; hoping to rewrite those and make MIT-licensed versions.\nNeed to come up with some better process but so far just struggling with getting the skeleton laid out myself. Ideas welcome."
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-02 23:46:59+00:00",
+                    "text": "Thought I tried the quotes (I tried Unicode decimal and hex, ... too) but it works. I might quote all the titles.\nThanks!   Still have odd things like the links on the RHS of the index.html page not working when on fortran-lang.org but working on my local server, and not being able to scroll to the bottom of the LHS index in Firefox but the basic structure looks to be coming together OK."
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-04 14:24:10+00:00",
+                    "text": "If I could ask for a build, I need a trail build to see what links work on a build on fortran-lang.org; I have asked for permission and\nclarification on use of the ISO standard,  but I think based on this document that the ISO standard can be used as a reference\nin this context so this can go forward, albeit this a lot to go this will create a complete skeleton for the standard generic intrinsics\nthat hopefully everyone can help complete.\nhttps://www.iso.org/files/live/sites/isoorg/files/store/en/PUB100206.pdf\n\nCopy parts of a standard for your book or software\nCiting standards or including extracts of standards is encouraged as\nlong as there is the correct acknowledgement and the conditions of your\nlicence are respected. Please contact IEC or ISO for authorization."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-04 23:56:56+00:00",
+                    "text": "If I could ask for a build\n\nYou can just add a comment with the phrase #build_preview and you will get a new preview. Give it a try."
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-05 02:09:19+00:00",
+                    "text": "#build preview"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-05 17:43:53+00:00",
+                    "text": "#178"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-05 17:53:03+00:00",
+                    "text": "#build preview\n      ^\n\nYou are missing an underscore, try with #build_preview."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-05 18:02:31+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-05 18:06:09+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-05 18:25:53+00:00",
+                    "text": "There is a workflow running scanning all comments posted for the string #build_preview, if it occurs in any context it will trigger a new preview build. Note that this comment and my previous ones did not trigger the preview build because I put a non-printing character in via #</space>build_preview.\nThe difference between your previous comments and mine above is the underscore in #build_preview. Using # as character to signal a special command is a rather suboptimal design choice, since the GitHub UI will try to expand it to a reference. Also, I'm not sure if the preview build workflow is actually documented anywhere.\nAnother thing about the current mechanism is that it is kind of hard to explain without either triggering a new preview build or causing confusion..."
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-06 15:24:04+00:00",
+                    "text": "#build_preview\nThe basic layout is working including the links and a general style has emerged that I think works; except for an oddity where I have to reduce my zoom level for the entire auto-built index to appear. There is still a large amount of work on the descriptions themselves to be done, which I would encourage everyone to help with; with good example programs needed and/or links to additional resources but this is at the point of being usable in my opinion, and still can be converted to plain text and actual man-pages via some basic GNU scripting and the use of pandoc(1); so in this form it can still be used to generate ULS documentation and be used as input to create an fpm-man(1) utility for access via a CLI tool; although the addition of mathematical expressions and links and graphics would complicate that. Have not tried it, but pandoc(1) can generate HTML and Adobe PDF as well, but even if not can use groff(1) on the man-pages and/or JavaScript as is done on the M_intrinsics repository to create a single document as well, hopefully. So how far to go beyond ASCII documentation at the risk of loosing the ASCII interface alternative is a big question.  It will be an extended effort to go significantly further than this so I am looking for feedback on how well the MINIBOOK format appears to work to everyone, etc."
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-06 15:29:15+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "milancurcic",
+                    "date": "2021-12-06 15:32:41+00:00",
+                    "text": "The top-level table in the latest preview looks very nice, great work @urbanjost!"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-06 16:51:21+00:00",
+                    "text": "#build_preview\nThanks. Well, if you build it will they come?"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-06 16:56:22+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-06 21:15:20+00:00",
+                    "text": "#build_preview\nToo fast, or should not put comment on same line? Try again"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-06 21:20:06+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-06 21:20:08+00:00",
+                    "text": "Too fast, or should not put comment on same line? Try again\n\nI think the complete build takes at least 3 to 4 min at the moment. For quick checks building locally might be an option as the rebuild is incremental, but at least for me that stopped working after I upgraded to Ruby 3 on my system."
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-06 21:42:31+00:00",
+                    "text": "Ahhh. I went back to ruby 2.7 and I can do local builds again; plus I was not waiting long enough. As soon as I got a response I was looking, but if I just wait a few minutes after it shows up. Have to take a break on this but wanted to get some of the smaller things out of the way so this was at a presentable state. It is at a point where everything works and the response has been mild so I will work on this locally again and experiment a bit more with mathematical expressions and graphics unless something changes (never used kramdown before, etc...). Thanks again!\n#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-06 21:47:19+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-07 03:06:48+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-07 03:11:42+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-07 05:02:46+00:00",
+                    "text": "#build_preview\nfor EXP"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-07 05:05:36+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-07 05:07:38+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-07 05:09:40+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-09 02:30:05+00:00",
+                    "text": "#build_preview\nLEN"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-09 02:34:02+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-09 02:55:46+00:00",
+                    "text": "#build_preview\nAdd an example of specifying the length of a character variable at run time even if not allocatable."
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-09 03:00:29+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-09 03:09:21+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-09 03:13:02+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-09 14:13:03+00:00",
+                    "text": "#build_preview\nerrata and formatting corrections"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-09 14:18:08+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-09 16:41:23+00:00",
+                    "text": "#build-refresh"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-09 22:37:13+00:00",
+                    "text": "#build-rebuild\nAdd copies of preliminary man-pages and fman(1) program"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-09 22:44:47+00:00",
+                    "text": "I'm not sure if we can properly host Fortran source on the webpage. In any case a separate repository with the source and a release tag holding any generated artifacts, which are linked from the webpage seem preferable."
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-10 01:00:36+00:00",
+                    "text": "#build-preview\nmoved supplemental files to AlterVista"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-10 01:19:54+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-10 01:23:55+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-10 09:54:54+00:00",
+                    "text": "moved supplemental files to AlterVista\n\nIf you like we could maintain them in a repository in the @fortran-lang namespace.\ncc @fortran-lang/admins"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-10 12:06:49+00:00",
+                    "text": "If they cannot be allowed in the directories themselves I am fine with them being on an ID of mine; it is experimental at this time.\nNot quite sure what it would take to have them under fortran-lang.org but right now they change so frequently it is actually convenient with them on AlterVista, at least for me.\n#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-10 12:11:55+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-12 00:59:44+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-12 01:03:33+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-12 21:36:47+00:00",
+                    "text": "I was hoping this would be accessible from at least GNU/Linux and Unix via programs like lynx/links/w3m; but the index shows on each page, which makes it awkward:\n    lynx https://fortran-lang.org/pr/347/learn/intrinsics/ACHAR\nperhaps I can directly insert HTML to mask that, but I do not think that is supported by the CLI browsers.  Any thoughts appreciated. I have not found a way to turn off the index on the individual pages as they are built automatically, so I do not see an easy way to insert directives into the index, other than perhaps creating everything as HTML instead of as markdown.\n#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-12 21:40:59+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-13 05:31:55+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-13 05:35:35+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-13 15:46:57+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-13 15:51:37+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-14 01:32:42+00:00",
+                    "text": "#build_preview\nVERIFY and slidy view of procedures. I think I am becoming a slidy fan."
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-14 01:37:47+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-14 19:35:38+00:00",
+                    "text": "#build_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-14 19:40:03+00:00",
+                    "text": "This PR has been built with Jekyll and can be previewed at: https://fortran-lang.org/pr/347/"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-26 02:20:56+00:00",
+                    "text": "#build preview"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-30 07:46:09+00:00",
+                    "text": "#build preview\nThe master files are the kramdown files, so anyone else that wants to contribute can just change the files. A particular style that is basically a man-page format is being followed, with a simple set of rules being followed to allow for simple parsing and to maintain compatibility with pandoc(1) for conversions. As an alternate way of contributing, particularly example programs, see\nhttps://urbanjost.github.io/fortran-intrinsic-descriptions/;  or we can move this to the Fortran Wiki, which has a much lower bar for contributing and less issues with potential copyright issues.  I have not gotten the type of definitive answer from the ISO standard support yet, although there is a page saying that as long as you properly acknowledge the standard as a referenence that reasonable use is permitted. Anyone published a Fortran manual that has some feedback on how to navigate properly using the standard without infringing on it?\nPS:  I have yet to get a LaTex formula to work with kramdown on this page. Anyone have an example?"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-30 16:04:46+00:00",
+                    "text": "I have yet to get a LaTex formula to work with kramdown on this page. Anyone have an example?\n\nI remember using MathJax with jekyll / kramdown in the past. There was an issue with TeX and markdown sharing a lot of control characters, something hacky was needed to get those working together like passthroughs or similar. I could look it up, but maybe there is a better solution than TeX? I recall @certik commented on the usage of SymPy for rendering formulas instead of TeX."
                 }
             ]
         },
@@ -249,6 +851,11 @@
                     "user": "aslozada",
                     "date": "2021-10-22 21:46:19+00:00",
                     "text": "GNU License Logos: https://www.gnu.org/graphics/license-logos.en.html\nOfficial logos:  GFDL\nAlternative Logos: CC BY 3.0"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-20 11:14:54+00:00",
+                    "text": "While not official yet, I've have been using the \u201cfpm color palette\u201d for several Fortran related projects now.\n\nSo far it appears at:\n\nFrench Wikipedia\nFortranCon/PackagingCon presentation of fpm\nfpm docs\nTOML-Fortran logo"
                 }
             ]
         },
@@ -1442,6 +2049,16 @@
                     "user": "LKedward",
                     "date": "2021-07-01 08:49:00+00:00",
                     "text": "Thanks everyone!"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-17 14:53:17+00:00",
+                    "text": "#delete_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-17 14:53:42+00:00",
+                    "text": "The preview build for this PR has now been deleted."
                 }
             ]
         },
@@ -2006,6 +2623,16 @@
                     "user": "awvwgk",
                     "date": "2021-06-17 20:24:49+00:00",
                     "text": "With three approvals I will go ahead and merge this patch."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-17 14:52:57+00:00",
+                    "text": "#delete_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-17 14:53:21+00:00",
+                    "text": "The preview build for this PR has now been deleted."
                 }
             ]
         },
@@ -2187,6 +2814,21 @@
                     "user": "awvwgk",
                     "date": "2021-05-25 11:44:07+00:00",
                     "text": "If you create an account and let me know the username I can add you to the team as admins.\n\nThanks, I'm going under @awvwgk there as well."
+                },
+                {
+                    "user": "kjelljorner",
+                    "date": "2021-12-06 15:43:44+00:00",
+                    "text": "I'm currently working on a Python interface to a legacy Fortran code, involving sending Python callback functions to Fortran. Also considering the options for multi-platform packaging on PyPi using scikit-build + cmake and cibuildwheel. Maybe would be a good time to try to revive this effort @awvwgk?"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-06 15:50:20+00:00",
+                    "text": "I currently have shifted my priorities from the Fortran-lang webpage to the fpm documentation (see https://awvwgk.github.io/fpm-docs). Hopefully, the framework explored there will find adoption for other Fortran-lang resources in the future (stdlib? minibooks?), especially since we now actually have first class internationalization support there."
+                },
+                {
+                    "user": "kjelljorner",
+                    "date": "2021-12-06 16:00:31+00:00",
+                    "text": "I've seen that - it looks really good! I might add some of the work on callbacks and error handling that I have been investigating over the next few weeks and then see if there is anyone on the Discourse that wants to join in."
                 }
             ]
         },
@@ -2424,6 +3066,16 @@
                     "user": "certik",
                     "date": "2021-04-20 15:23:03+00:00",
                     "text": "Here is the Tweet, I copied & pasted from Milan's post: https://twitter.com/fortranlang/status/1384527637737971718"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-17 14:51:50+00:00",
+                    "text": "#delete_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-17 14:52:18+00:00",
+                    "text": "The preview build for this PR has now been deleted."
                 }
             ]
         },
@@ -3538,6 +4190,21 @@
                     "user": "vmagnin",
                     "date": "2021-03-22 09:17:12+00:00",
                     "text": "I have just committed the French translation of the compilers.md page in my fork, corresponding to the latest 2021-03-06 English version:\nhttps://github.com/vmagnin/fortran-lang.org/commits/i18n/_i18n/fr/compilers.md\nIt was quite difficult to translate, not only because there is a lot of technical details but also because most paragraphs are written in a commercial style."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-01 21:43:56+00:00",
+                    "text": "I guess it is time to close this topic, we can revive this branch from 1fb9900 to get the wonderful translations already contributed here. For now I'll focus on building the fpm documentation to explore how far we can get with sphinx. Maybe we can transfer some of the knowledge and experience from there to rebuilt our webpage with support for translations in the future. Having a multilingual Fortran homepage is still high on my wish list."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-17 14:52:38+00:00",
+                    "text": "#delete_preview"
+                },
+                {
+                    "user": "github-actions[bot]",
+                    "date": "2021-12-17 14:53:00+00:00",
+                    "text": "The preview build for this PR has now been deleted."
                 }
             ]
         },
@@ -4193,6 +4860,11 @@
                     "user": "awvwgk",
                     "date": "2020-12-07 19:17:15+00:00",
                     "text": "This is still using the workflow file from the main repo rather than from this branch. Seems like the event triggering the build preview through a comment is not associated with the PR but with the latest commit on the main branch instead?\nSo you have to trust me that this will fix the issue with the build preview \ud83d\ude09"
+                },
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-05 17:47:23+00:00",
+                    "text": "#build preview"
                 }
             ]
         },
@@ -4389,6 +5061,11 @@
                     "user": "jacobwilliams",
                     "date": "2021-09-05 14:31:43+00:00",
                     "text": "I really like the https://www.python.org one, where they have a 5 very short examples.\nTheir \"launch interactive shell\" is also amazing.... maybe one day with LFortran we could have that too!"
+                },
+                {
+                    "user": "ivan-pi",
+                    "date": "2021-12-25 13:55:01+00:00",
+                    "text": "The Taichi GitHub landing page also features a Mandelbrot example (both parallelized and executed on GPU). Taichi is a domain-specific language for high-performance parallel computing based on Python syntax."
                 }
             ]
         },
@@ -7543,6 +8220,11 @@
                     "user": "awvwgk",
                     "date": "2021-05-16 18:33:15+00:00",
                     "text": "I started working on sphinx based version of the webpage at my fork https://github.com/awvwgk/fortran-lang.org in the sphinx branch. It is still quite experimental at the moment, but so far sphinx looks really promising."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-01 21:41:01+00:00",
+                    "text": "Coming back to this issue after a while, it seems like there is some development in the sphinx themes I checked previously. Styling with CSS is now quite straight-forward, also the sphinx-panels has been superseded by the sphinx-design project, which allows usage of almost all bootstrap we need. And we can translate it (there are a few rough edges)."
                 }
             ]
         },

--- a/community/github_stats_data/data-fortran-lang-fpm.json
+++ b/community/github_stats_data/data-fortran-lang-fpm.json
@@ -2,6 +2,147 @@
     "name": "fortran-lang/fpm",
     "issues": [
         {
+            "number": 642,
+            "user": "awvwgk",
+            "date": "2021-12-27 12:57:24+00:00",
+            "title": "Replace polymorphic assignment with move_alloc",
+            "text": "allows building with GCC 5 (conda-forge Windows toolchain)",
+            "comments": []
+        },
+        {
+            "number": 638,
+            "user": "awvwgk",
+            "date": "2021-12-19 10:13:34+00:00",
+            "title": "Creating compiler toolchains",
+            "text": "We currently detect our compiler toolchain by identifying it from the Fortran compiler, with the default being gfortran. This is somewhat suboptimal since it doesn't account for the C compiler and because changes in the PATH are not correctly considered in our toolchain.\nHere is a proposal for creating an fpm compiler command inspired by spack compiler:\n\nallow to find installed compilers by searching the PATH for standard names (done automatically on first invocation)\ninspection/modification of existing compiler toolchains possible (checksum?)\navailable toolchains are user settings in ~/.config/fpm/toolchain/*.toml or ~/.config/fpm/toolchain.toml (individual files might be easier to share/reuse)\nspecify the default toolchain in ~/.config/fpm/config.toml\nthe commands for --compiler, --c-compiler, ... are passed to fpm compiler internally (create new toolchain on demand)\ntoolchain name is used to prefix build output directory (maybe include a digest/slug?)\npossibility to perform an integrity check of toolchain (in case of system upgrade, ...)",
+            "comments": []
+        },
+        {
+            "number": 637,
+            "user": "urbanjost",
+            "date": "2021-12-15 11:16:09+00:00",
+            "title": "minor bug when a program file does not contain a PROGRAM directive",
+            "text": "Description\nA program directive is optional, but if your main program does not contain a PROGRAM directive it is not identified as a program. It would be non-trivial (I think) to scan a file and stop on a subroutine or function defininition and then ignoring comments to decide a file is a main program source  (and not an INCLUDE file) by seeing if code remains with a more general file parser, but should the documentation mention a PROGRAM directive is mandatory for fpm?  Or maybe the message could mention if a .f90/.f file is skipped?\nExpected Behaviour\nA program would be built\nVersion of fpm\n0.5.0\nPlatform and Architecture\nAll\nAdditional Information\nNo response",
+            "comments": []
+        },
+        {
+            "number": 636,
+            "user": "awvwgk",
+            "date": "2021-12-14 22:16:11+00:00",
+            "title": "Remove duplicated documentation from this repo",
+            "text": "Now that we have a dedicated repository for the fpm documentation we should try to minimize the duplication and overlap of different information sources.\n\n move everything from the ford pages section: https://fortran-lang.github.io/fpm/page/index.html\n move markdown documents:\n\n https://github.com/fortran-lang/fpm/blob/main/PACKAGING.md\n https://github.com/fortran-lang/fpm/blob/main/manifest-reference.md\navailable at: https://fpm.fortran-lang.org/en/spec/manifest.html\n\n\n check wiki for salvageable documentation: https://github.com/fortran-lang/fpm/wiki",
+            "comments": []
+        },
+        {
+            "number": 635,
+            "user": "awvwgk",
+            "date": "2021-12-13 21:40:25+00:00",
+            "title": "Only compile source of dependencies needed for project",
+            "text": "Not sure whether we currently have a mechanism to discard disconnected target graphs from the compilation which are not needed for any module in the library. It could be beneficial to only compile source code we actually use in our project, however we have to be careful to not discard non-module functions (either bind(c) or declared outside of a module).\nThis way we could depend on stdlib without having to worry about a too large single file version which can't be compiled anymore and lose our most important bootstrap mechanism.",
+            "comments": [
+                {
+                    "user": "ivan-pi",
+                    "date": "2021-12-14 08:38:02+00:00",
+                    "text": "For stdlib specifically, I've been thinking it would be nice to have the possibility to only download/build selected modules specified in the manifest. I think what you are suggesting here is precisely this, however fpm would still be required to parse everything."
+                },
+                {
+                    "user": "LKedward",
+                    "date": "2021-12-15 12:32:37+00:00",
+                    "text": "This should be possible and is something I have thought would be useful.\n\n... however we have to be careful to not discard non-module functions\n\nThe same goes for submodule objects which are not technically part of the module dependency tree (hence #556)."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-15 12:45:15+00:00",
+                    "text": "The same goes for submodule objects which are not technically part of the module dependency tree (hence #556).\n\nWould a weak/link-time dependency of the archive or the executable target help to capture the complete graph?"
+                },
+                {
+                    "user": "LKedward",
+                    "date": "2021-12-15 12:50:51+00:00",
+                    "text": "Would a weak/link-time dependency of the archive or the executable target help to capture the complete graph?\n\nYes, I think something like that would work."
+                }
+            ]
+        },
+        {
+            "number": 634,
+            "user": "p-costa",
+            "date": "2021-12-12 22:44:51+00:00",
+            "title": "Better extraction of the Fortran compiler from the MPI wrapper",
+            "text": "This PR adds a very minor change.\nFirst, it checks the MPI wrapper flag -show instead of -show-me:command, since the latter is absent in libraries like MPICH, while -show seems ubiquitous (at least in MPICH, OpenMPI, and Spectrum MPI have it).\nSecond, it strips the output string into several parts and fetches the first (command) part, to handle command outputs like:\n$ mpifort --show\n/usr/bin/gfortran -I/usr/include -pthread -I/usr/lib/openmpi -L/usr/lib/openmpi -Wl,-rpath -Wl,/usr/lib/openmpi -Wl,--enable-new-dtags -lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh -lmpi`;\neven with the previous flag, the current implementation would not detect the compiler correctly in some instances like the following output I got from Spectrum MPI.\n$ mpif90 -showme:command\ngfortran -I/long_path_name/spectrum_mpi/10.4.0/binary/lib/fortsupport_gfortran\nBut perhaps at a later stage, one could do better as suggested in #354.\nThis seems like a very minor fix, so I did not open an issue as suggested in the contributing guidelines. However, if it is best, I can close this and open an issue first.",
+            "comments": [
+                {
+                    "user": "p-costa",
+                    "date": "2021-12-12 23:23:48+00:00",
+                    "text": "One issue that this PR does not solve is that outputs like the following:\n\n$ mpifort -show\ngfortran-11 -g -framework OpenCL (...)\nor\n\n$ mpifort -show\nxlf_r -I/long_path_name/compilers/cuda/10.1/none/include -lmpifort -lmpi -lcuda\nwill remain undetected since they do not match precisely gfortran or xlf90."
+                }
+            ]
+        },
+        {
+            "number": 633,
+            "user": "awvwgk",
+            "date": "2021-12-12 19:49:00+00:00",
+            "title": "Automatic location of package manifest interfers with commands independent project root",
+            "text": "Description\nUsing an fpm command which does not require to be in the project root will still attempt to find a package manifest.\nFor fpm new this can produce a spurious printout in the best case\n\u276f fpm new example\n + mkdir -p example\n + cd example\n + mkdir -p example/src\n + mkdir -p example/app\n + mkdir -p example/test\n + git init example\nInitialized empty Git repository in /home/awvwgk/projects/src/git/example/.git/\nfpm: Leaving directory '/home'\n\nOr create the new project in an unexpected location when inside another fpm project.\nExpected Behaviour\nHave a way for plugins and commands to require knowing the location of the package manifest. Only change directory if package manifest is actually required by command / plugin.\nVersion of fpm\n0.5.0\nPlatform and Architecture\nall\nAdditional Information\nNo response",
+            "comments": []
+        },
+        {
+            "number": 632,
+            "user": "tueda",
+            "date": "2021-12-11 08:01:55+00:00",
+            "title": "Module interface files of dev-dependencies don't need to be installed",
+            "text": "Description\nIf I understand correctly, dev-dependencies in the fpm.toml file specifies dependencies for development (e.g., tests), and this dependency should not be exposed to dependent projects in any way. But when installing a library by fpm install, fpm 0.5.0 seems to copy module interface files of dev-dependencies of the library, which should not happen.\nSteps to reproduce the problem:\nfpm new bug --lib --test\ncd bug\nsed -i 's/library = false/library = true/' fpm.toml\necho '[dev-dependencies]' >>fpm.toml\necho 'test-drive.git = \"https://github.com/fortran-lang/test-drive\"' >>fpm.toml\nfpm install --prefix $(pwd)\nHere, the sed ... and echo ... commands write the following lines in fpm.toml:\n[install]\nlibrary = true\n[dev-dependencies]\ntest-drive.git = \"https://github.com/fortran-lang/test-drive\"\nThen, fpm install causes installation of .mod files of dev-dependencies (testdrive.mod and testdrive_version.mod in this example):\n# Update: build/gfortran_E691F5CC75D6381A/bug/libbug.a -> /home/tueda/tmp/20211211/bug/lib\n# Update: build/gfortran_E691F5CC75D6381A/bug.mod -> /home/tueda/tmp/20211211/bug/include\n# Update: build/gfortran_E691F5CC75D6381A/testdrive.mod -> /home/tueda/tmp/20211211/bug/include\n# Update: build/gfortran_E691F5CC75D6381A/testdrive_version.mod -> /home/tueda/tmp/20211211/bug/include\n\nExpected Behaviour\nfpm install should not install module interface files of dev-dependencies.\nVersion of fpm\n0.5.0\nPlatform and Architecture\nUbuntu 20.04.2 (5.10.60.1-microsoft-standard-WSL2), x86_64\nAdditional Information\nfpm 0.5.0 and gfortran 11.2.0_3 installed via Homebrew.",
+            "comments": [
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-13 21:08:36+00:00",
+                    "text": "Indeed, target specific dependencies and development dependencies shouldn't get installed. The installation step for the modules is implemented here\n\n  \n    \n      fpm/src/fpm/cmd/install.f90\n    \n    \n        Lines 72 to 73\n      in\n      d99ad59\n    \n    \n    \n    \n\n        \n          \n           call install_module_files(installer, targets, error) \n        \n\n        \n          \n           call handle_error(error) \n        \n    \n  \n\n\nby filtering out all modules from the targets:\n\n  \n    \n      fpm/src/fpm/cmd/install.f90\n    \n    \n         Line 119\n      in\n      d99ad59\n    \n    \n    \n    \n\n        \n          \n           call filter_modules(targets, modules) \n        \n    \n  \n\n\nThe implementation of the filter step can be found here:\n\n  \n    \n      fpm/src/fpm_targets.f90\n    \n    \n        Lines 679 to 700\n      in\n      d99ad59\n    \n    \n    \n    \n\n        \n          \n           subroutine filter_modules(targets, list) \n        \n\n        \n          \n               type(build_target_ptr), intent(in) :: targets(:) \n        \n\n        \n          \n               type(string_t), allocatable, intent(out) :: list(:) \n        \n\n        \n          \n            \n        \n\n        \n          \n               integer :: i, j, n \n        \n\n        \n          \n            \n        \n\n        \n          \n               n = 0 \n        \n\n        \n          \n               call resize(list) \n        \n\n        \n          \n               do i = 1, size(targets) \n        \n\n        \n          \n                   associate(target => targets(i)%ptr) \n        \n\n        \n          \n                       if (.not.allocated(target%source)) cycle \n        \n\n        \n          \n                       if (target%source%unit_type == FPM_UNIT_SUBMODULE) cycle \n        \n\n        \n          \n                       if (n + size(target%source%modules_provided) >= size(list)) call resize(list) \n        \n\n        \n          \n                       do j = 1, size(target%source%modules_provided) \n        \n\n        \n          \n                           n = n + 1 \n        \n\n        \n          \n                           list(n)%s = join_path(target%output_dir, & \n        \n\n        \n          \n                               target%source%modules_provided(j)%s) \n        \n\n        \n          \n                       end do \n        \n\n        \n          \n                   end associate \n        \n\n        \n          \n               end do \n        \n\n        \n          \n               call resize(list, n) \n        \n\n        \n          \n           end subroutine filter_modules \n        \n    \n  \n\n\nAn additional scope information to only select module files of required projects could be passed, but I'm currently not sure whether the targets still know which project they are associated to. I think we have to install all module files from the whole dependency tree of the library, since we include all those sources in the archive at the moment."
+                }
+            ]
+        },
+        {
+            "number": 630,
+            "user": "urbanjost",
+            "date": "2021-12-08 15:59:20+00:00",
+            "title": "just allow . on new subcommand instead of changing canonical path pro\u2026",
+            "text": "The previous change to make canon_path(3f) technically more correct or like realpath(3c) exposed other uses of the routine not compatible with a real realpath(3c) behavior, so making simple change to special-case the \".\" pathname or a null pathname in the new subcommand so that\nfpm new --backfill\nfpm new . --backfill\nwork; as currently the --backfill option requires a pathname including at least the base directory name, which is non-intuitive.\nor it cannot be used from within the actual project main directory.",
+            "comments": [
+                {
+                    "user": "urbanjost",
+                    "date": "2021-12-08 16:07:35+00:00",
+                    "text": "Note the change is made such that if the canonical name is subsequently returned by canon_path(3f) the code will still work, the change of \".\" to the current directory will just become redundant."
+                }
+            ]
+        },
+        {
+            "number": 629,
+            "user": "urbanjost",
+            "date": "2021-12-08 15:39:22+00:00",
+            "title": "make canon_path more canonical",
+            "text": "making canon_path more like realpath exposed uses of canon_path not compatible with a realpath call; so treating . or a missing name as a special case directly in the new subcommand.",
+            "comments": []
+        },
+        {
+            "number": 628,
+            "user": "urbanjost",
+            "date": "2021-12-08 14:32:12+00:00",
+            "title": "make canon_path more canonical",
+            "text": "canon_path is intended to be replaced with an equivalent of realpath(3c), and since there is already a procedure to get the current directory, a step towards canon_path returning what a realpath(3c) would is to replace a leading \".\" with the current directory.\nThis also allows the new subcommand to use the pathname \".\"  when the --backfill option is present. It has been a non-intuitive feature of fpm that a backfill requires a full pathname, as in\nfpm new `pwd` --backfill\ninstead of\nfpm new --backfill\nfpm new . --backfill",
+            "comments": []
+        },
+        {
+            "number": 627,
+            "user": "urbanjost",
+            "date": "2021-12-08 02:43:58+00:00",
+            "title": "only the file main.f90 is built if only one file exists in app/",
+            "text": "Description\nauto-build of files in the app/ directory only occurs if the file main.f90 exists. Even the case where main.f90 is renamed to main.F90\nis not built.\nfpm new bug\ncd bug\nmv app/main.f90 app/main.F90\ntree\n\u251c\u2500\u2500 app\n\u2502\u00a0\u00a0 \u2514\u2500\u2500 main.F90\n\u251c\u2500\u2500 fpm.toml\n\u2514\u2500\u2500 README.md\n\n1 directory, 3 files\n fpm build\n<ERROR>*cmd_build*:package error:Neither library nor executable found, there is nothing to do\nSTOP 1\nThis is true in general. If I have only the file app/myprogram.f90 in app/ it is not built automatically, but\nif I leave the trivial app/main.f90 file generated by fpm new and add the file app/myprogram.f90 both\nprograms are built just using build fpm.\nExpected Behaviour\nI expect that with auto-build on any programs in the app/ directory would be built, and that it would not require app/main.f90 to be present; as the src/ directory does not require src/main.f90 to be present for an auto-build to work.\nIf the file is explicitly added to the fpm.toml file it is built, but I do not expect that to be required.\nAlso, somewhat confusingly, if I have app/main.f90 and app/main.F90  in the above I get \"main\" and \"bug\" built; I might expect an error to occur indicating there is a duplicate and for main.F90 to also be building an executable called \"bug\" but that is maybe more arguable.\nVersion of fpm\n0.4.0\nPlatform and Architecture\nAll\nAdditional Information\nAlso, reserving the name \"main.f90\"  is perhaps OK, but it seems more natural for the new subcommand to create a file called\n\"package_name\".f90 instead of \"main.f90\"; but that does not get built either unless this behavior (requiring main.f90 to exist to auto-build).  Looks like instead of testing for main.f90 testing if there are contents in the app/ directory would correct at least part of this (not seeing if filenames are the same ignoring suffixes would need another change though, I think).",
+            "comments": [
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-13 21:11:49+00:00",
+                    "text": "This could be an issue with how we handle the default executable, test and example target. In case of automatic detection we actually don't have to create those targets in the manifest because they will be found later, this might be something that is controlled completely by the setup of the manifest data types.\nThe build table is parsed before we parse the executables and the defaults are applied even later."
+                }
+            ]
+        },
+        {
             "number": 625,
             "user": "ivan-pi",
             "date": "2021-11-27 23:33:55+00:00",
@@ -17,6 +158,11 @@
                     "user": "rouson",
                     "date": "2021-11-30 09:12:21+00:00",
                     "text": "I think this is unnecessary and not necessarily advisable unless required to address a specific problem.   See my comments in the cited Discourse thread."
+                },
+                {
+                    "user": "ivan-pi",
+                    "date": "2021-12-01 13:14:44+00:00",
+                    "text": "Given that no specific problem has been encountered yet, I will close this for the time-being."
                 }
             ]
         },
@@ -115,6 +261,26 @@
                     "user": "LKedward",
                     "date": "2021-11-30 16:16:19+00:00",
                     "text": "somewhat ironically, I immediately miss being able to get all the messages on a built project. Is that something you were going to build back in?\n\nI agree we should build this in but I'm not sure what the user interface would be right now (fpm log, fpm build --log?) and so I suggest leaving this for a future PR."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-04 10:46:25+00:00",
+                    "text": "A minor issue I encountered is that the output is not correctly aligned, the compiling... case starts a column before the done and failed output.\n fpm_backend_console.f90                done.\n fpm_constants.f90                      done.\n fpm_manual.f90                         done.\n fpm_strings.f90                        done.\nscript.f90                             compiling...\nconstants.f90                          compiling...\nversion.f90                            compiling...\n\nAnother thing, building a deeply nested project like TOML Fortran leads to printout like this\n + mkdir -p build/dependencies\n color.f90                              done.\n constants.f90                          done.\n version.f90                            done.\n tomlf.c                                done.\n datetime.f90                           done.\n error.f90                              done.\n verify.f90                             done.\n diagnostic.f90                         done.\n main.f90                               done.\n convert.f90                            done.\n utils.f90                              done.\n value.f90                              done.\n keyval.f90                             done.\n base.f90                               done.\n sort.f90                               done.\n vector.f90                             done.\n structure.f90                          done.\n array.f90                              done.\n table.f90                              done.\n type.f90                               done.\n ser.f90                                done.\n tokenizer.f90                          done.\n keyval.f90                             done.\n merge.f90                              done.\n character.f90                          done.\n array.f90                              done.\n table.f90                              done.\n build.f90                              done.\n de.f90                                 done.\n all.f90                                done.\n tomlf.f90                              done.\n libtoml-f.a                            done.\n toml-f                                 done.\n[100%] Project compiled successfully.\n\nWhere files with different paths but identical basename look like they are appearing twice in the compilation step."
+                },
+                {
+                    "user": "zoziha",
+                    "date": "2021-12-04 11:42:48+00:00",
+                    "text": "First of all, thanks to this PR, this gives the user experience a big step up.\nAnd, is it possible to add output path information of the target binaries to the --verbose information? It contains hash values that are easy for users to know, that will be useful.\n# `fpm build --verbose` info\n <INFO> BUILD_NAME: build\\gfortran\n <INFO> COMPILER:  gfortran\n <INFO> C COMPILER:  gcc\n <INFO> COMPILER OPTIONS:   -Wall -Wextra -Wimplicit-interface -fPIC -fmax-errors=1 -g -fcheck=bounds -fcheck=array-temps -fbacktrace -fcoarray=single\n <INFO> C COMPILER OPTIONS:\n <INFO> LINKER OPTIONS:\n <INFO> INCLUDE DIRECTORIES:  []\n[100%] Project compiled successfully.\nFor example, when I first used fpm build, I couldn't know exactly where the generated binary was in unless: fpm run --runner file.\nProject is up to date\nbuild\\gfortran_2A42023B310FA28D\\app\\fpm.exe: PE32+ executable (console) x86-64, for MS Windows"
+                },
+                {
+                    "user": "LKedward",
+                    "date": "2021-12-06 09:02:54+00:00",
+                    "text": "A minor issue I encountered is that the output is not correctly aligned, the compiling... case starts a column before the done and failed output.\n\nAh yes, I'll sort that out.\n\nWhere files with different paths but identical basename look like they are appearing twice in the compilation step.\n\nI'll have to have a think about what the best way to address this is. Including full paths by default may lead to a lot of redundant output noise."
+                },
+                {
+                    "user": "LKedward",
+                    "date": "2021-12-06 09:07:16+00:00",
+                    "text": "And, is it possible to add output path information of the target binaries to the --verbose information? It contains hash values that are easy for users to know, that will be useful.\n\nThanks @zoziha - the output path hash was removed from the verbose summary information because it technically varies on a per-file basis (it can be different for different files with different flags). However, you can run fpm build --list to quickly get the output paths before building your project."
                 }
             ]
         },
@@ -133,7 +299,7 @@
                 {
                     "user": "urbanjost",
                     "date": "2021-11-23 02:51:11+00:00",
-                    "text": "I tend to break my tests into a confidence test that is very quick but exercises a few key features, a collection of short tests that do coverage, and what I usually call benchmark tests that are long-running. When I have moved those to fpm I have been breaking them up by name with the globbing feature like \"run test 'bench_', run test 'general_' and run test confidence; and in one case I made the test program a program that takes parameters that select which directory to run and put the other test programs into directories and did not find any of those quite hit the mark, so I think I will take  a look at how pytest does it. Any other examples of models to try?  I was thinking about lists of tests or directories that you could give a name to in the fpm.toml file, and then do something like \"run test -type plot\" or \"run test -type benchmark\", and earlier I had a PR that allowed for a \"y/n\" reply to a prompt that no one else seemed to like so I didn't pursue it."
+                    "text": "I tend to break my tests into a confidence test that is very quick but exercises a few key features, a collection of short tests that do coverage, and what I usually call benchmark tests that are long-running. When I have moved those to fpm I have been breaking them up by name with the globbing feature like \"run test 'bench_*', run test 'general_*' and run test confidence; and in one case I made the test program a program that takes parameters that select which directory to run and put the other test programs into directories and did not find any of those quite hit the mark, so I think I will take  a look at how pytest does it. Any other examples of models to try?  I was thinking about lists of tests or directories that you could give a name to in the fpm.toml file, and then do something like \"fpm run test -type plot\" or \"fpm run test -type benchmark\", and earlier I had a PR that allowed for a \"y/n\" reply to a prompt that no one else seemed to like so I didn't pursue it."
                 }
             ]
         },
@@ -492,6 +658,11 @@
                     "user": "urbanjost",
                     "date": "2021-11-30 03:54:50+00:00",
                     "text": "It says commonmark is a subset of MyST so I made a commonmark subdirectory in the fpm-tools/docs directory but I do not have an easy way to test it that I know of.  Do those look good?"
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-14 22:01:03+00:00",
+                    "text": "New docs are up, lets move all further discussion about the documentation to https://github.com/fortran-lang/fpm-docs"
                 }
             ]
         },
@@ -4543,7 +4714,7 @@
             "user": "rouson",
             "date": "2021-04-01 14:47:53+00:00",
             "title": "Let's change the name of the default branch to \"main\"",
-            "text": "Please see https://www.zdnet.com/article/github-to-replace-master-with-main-starting-next-month/.",
+            "text": "Please see https://www.zdnet.com/article/github-to-replace-master-with-main-starting-next-month/.\nBeside fpm those repositories are currently using master as name for the default branch\n\n https://github.com/fortran-lang/stdlib\n https://github.com/fortran-lang/stdlib-docs\n https://github.com/fortran-lang/fpm-haskell\n https://github.com/fortran-lang/fpm-registry\n https://github.com/fortran-lang/fortran-lang.org\n https://github.com/fortran-lang/talks\n https://github.com/fortran-lang/benchmarks\n https://github.com/fortran-lang/fftpack",
             "comments": [
                 {
                     "user": "milancurcic",
@@ -4558,7 +4729,7 @@
                 {
                     "user": "awvwgk",
                     "date": "2021-04-01 15:35:46+00:00",
-                    "text": "I'm all for migrating the default branch name, but I don't think it makes much sense unless it happens for all @fortran-lang repositories. Beside fpm those repositories are currently using master as name for the default branch\n\nhttps://github.com/fortran-lang/stdlib\nhttps://github.com/fortran-lang/stdlib-docs\nhttps://github.com/fortran-lang/fpm-haskell\nhttps://github.com/fortran-lang/fpm-registry\nhttps://github.com/fortran-lang/fortran-lang.org\nhttps://github.com/fortran-lang/talks\nhttps://github.com/fortran-lang/benchmarks"
+                    "text": "I'm all for migrating the default branch name, but I don't think it makes much sense unless it happens for all @fortran-lang repositories."
                 },
                 {
                     "user": "milancurcic",
@@ -5013,6 +5184,21 @@
                     "user": "awvwgk",
                     "date": "2021-11-24 09:37:03+00:00",
                     "text": "Note that the formula above is outdated. I'm maintaining a tap for fpm at https://github.com/awvwgk/homebrew-fpm for my programming course. However, I didn't get it to build on Linuxbrew so far, due to the choice of GFortran default version.\nThere is no downside submitting it, but I'm not a brew user. Feel free to submit the formula if you like."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-30 09:43:42+00:00",
+                    "text": "Homebrew does only accept stable software in homebrew-core (e.g. LFortran got rejected), therefore I don't think it makes send to submit fpm there. However, I can offer to migrate my tap to the @fortran-lang namespace if there is interest and we can maintain Fortran related packages collaboratively."
+                },
+                {
+                    "user": "rouson",
+                    "date": "2021-12-30 22:04:04+00:00",
+                    "text": "@awvwgk I'm interested in this and, as I mentioned above, I think it will do a lot to increase the likelihood of people adopting fpm.  Many novice users who are unfamiliar with building open-source software might not try a package that's not available via package manager."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-30 22:39:25+00:00",
+                    "text": "Thanks, Damian. I'm looking for at least one user interested in maintaining this tap together with me. If you want I can add you as a collaborator to the repo."
                 }
             ]
         },
@@ -6538,6 +6724,11 @@
                     "user": "certik",
                     "date": "2021-02-12 14:39:49+00:00",
                     "text": "@awvwgk finally somebody is doing it! Thanks for the link."
+                },
+                {
+                    "user": "awvwgk",
+                    "date": "2021-12-13 19:15:46+00:00",
+                    "text": "@wclodius2 @jvdp1 This might be needed to allow using C++ in the fpm version of stdlib (wclodius2/stdlib#6)"
                 }
             ]
         },
@@ -17040,6 +17231,11 @@
                     "user": "certik",
                     "date": "2021-02-19 16:52:25+00:00",
                     "text": "I just created an issue #365 where we should discuss where to host such packages."
+                },
+                {
+                    "user": "ivan-pi",
+                    "date": "2021-12-14 08:27:22+00:00",
+                    "text": "Just ticked off two more packages from @jacobwilliams. Thanks Jacob for your effort."
                 }
             ]
         },

--- a/community/github_stats_data/data-j3-fortran-fortran_proposals.json
+++ b/community/github_stats_data/data-j3-fortran-fortran_proposals.json
@@ -2,6 +2,35 @@
     "name": "j3-fortran/fortran_proposals",
     "issues": [
         {
+            "number": 241,
+            "user": "jacobwilliams",
+            "date": "2021-12-13 02:38:00+00:00",
+            "title": "for loop",
+            "text": "Not sure if this has already been proposed or not. But I keep wishing Fortran had something like the python for style loops like this:\nfor x in [10, 23, 1]:\n   do_something(x)\nor with zip:\nfor x,y in zip([10,23,1], ['a', 'b', 'cc']):\n  do_something(x,y)\nof course, the fortran way would be something like that:\ninteger :: i  ! just a counter\ninteger,dimension(3),parameter :: vals = [10, 23, 1]\ncharacter(len=2),dimension(3),parameter :: cals = ['a ', 'b ', 'cc']\ndo i = 1, 3\n  call do_something(vals(i), cals(i))\nend do\nWhat do people think?\nI don't know what the syntax would be...\nfor (x => [10, 23, 1], c => ['a ', 'b ', 'cc'])\n  call do_something(x,c)\nend for",
+            "comments": [
+                {
+                    "user": "certik",
+                    "date": "2021-12-13 05:48:18+00:00",
+                    "text": "Yes, Julia also has this feature. I think this can be done, it would bring Fortran closer to Python and Julia."
+                },
+                {
+                    "user": "cmacmackin",
+                    "date": "2021-12-13 18:57:32+00:00",
+                    "text": "I like the idea. I think maybe we should use something different than pointer assignment for the syntax though. This is because\n\nIt makes it look like the counter variable is being associated with the entire array.\nUsing a new operator (e.g., ->) leaves open the possibility that it could be overridden for derived types, giving the possibility of custom iterators.\n\nWe don't need to think out all the technicalities of how such custom iterators would be implemented right now, but we can at least leave the possibility open for the future."
+                },
+                {
+                    "user": "jacobwilliams",
+                    "date": "2021-12-13 21:17:17+00:00",
+                    "text": "Another option is a new .in. operator."
+                },
+                {
+                    "user": "Beliavsky",
+                    "date": "2021-12-14 15:44:11+00:00",
+                    "text": "I have wanted the same thing and support the proposal, but note that Impure elemental subroutines can simulate for loops over collections"
+                }
+            ]
+        },
+        {
             "number": 240,
             "user": "ivan-pi",
             "date": "2021-11-11 11:11:53+00:00",
@@ -625,6 +654,16 @@
                     "user": "FortranFan",
                     "date": "2021-08-28 21:57:00+00:00",
                     "text": "I didn't understand your argument. Can you elaborate on this? My understanding is that Rust does not have exceptions\n\n@certik, when I mentioned \"exception\" I only meant it as in ordinary English usage as illustrated in this quote! :-)"
+                },
+                {
+                    "user": "Beliavsky",
+                    "date": "2021-12-08 16:20:52+00:00",
+                    "text": "Besides making end associate optional, an alternative would be to allow end associate to pertain to a list of named variables, so that the sample code in the OP could be written\nassociate(val1 => (some_expr))\n  associate(val2 => val1 + another_expr)\n    associate(val3 => val2 + yet_another_expr)\n      result = val1 + val2 * val3\nend associate (val1, val2, val3)\n\nIt would resemble the syntax deallocate(val1, val2, val3). I don't mind a single end associate statement, but having many end associate statements at the end of a program unit is so verbose and tedious that many Fortranners will use good old local variables instead."
+                },
+                {
+                    "user": "Beliavsky",
+                    "date": "2021-12-17 16:38:12+00:00",
+                    "text": "As an alternative to a bunch of end associate statements at the end of a program unit, one could introduce a statement\nend associate_all that terminates all associations previously defined."
                 }
             ]
         },
@@ -7438,6 +7477,11 @@
                     "user": "ivan-pi",
                     "date": "2020-10-15 13:46:50+00:00",
                     "text": "Perhaps of interest: Algorithm 1005: Fortran Subroutines for Reverse Mode Algorithmic Differentiation of BLAS Matrix Operations. I could not find the actual Fortran routines. But it shows at least there is still large interest in having the possibility to automatically differentiate Fortran programs that rely on BLAS. Hopefully, LAPACK follows (in the paper they already show discuss algorithmic differentiation of the Cholesky decomposition).\n\nThe routines are now available on the ACM page: https://dl.acm.org/doi/10.1145/3382191"
+                },
+                {
+                    "user": "dalon-work",
+                    "date": "2021-12-20 19:31:40+00:00",
+                    "text": "CppCon 2021 recently posted a talk about implementing AD in LLVM as a plugin, using the compiler directly, instead of any language-level constructs. I assume this would affect Flang as well.\nhttps://youtu.be/1QQj1mAV-eY?t=2240\nAt the end he describes an effort to make this part of the C++ standard somehow."
                 }
             ]
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-dateutil
+PyGithub


### PR DESCRIPTION
While preparing #357 I found a small issue in the PRs script which manifests only in December. This PR fixes it and adds a requirements.txt file to keep track of the script dependencies.

We should also have a short guide on making a newsletter, which is for another PR.