### PR TITLE
Resolves issue fortran-lang#361 Updates spelling-mistakes

### DIFF
--- a/_data/learning.yml
+++ b/_data/learning.yml
@@ -93,7 +93,7 @@ reference-links:
     url: https://j3-fortran.org/
     description: J3 is the US National Body for the international Fortran standards committee
   
-  - name: "WG5: International Fortran Standards Committe"
+  - name: "WG5: International Fortran Standards committee"
     url: https://wg5-fortran.org/
     description: 
 

--- a/_data/learning.yml
+++ b/_data/learning.yml
@@ -93,7 +93,7 @@ reference-links:
     url: https://j3-fortran.org/
     description: J3 is the US National Body for the international Fortran standards committee
   
-  - name: "WG5: International Fortran Standards committee"
+  - name: "WG5: International Fortran Standards Committee"
     url: https://wg5-fortran.org/
     description: 
 

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -187,7 +187,7 @@
   categories: interfaces
   tags: gpu compute accelerator
 
-- name: foryxima
+- name: fortyxima
   url: https://bitbucket.org/aradi/fortyxima/src/develop/
   description: File system manipulation and unit testing framework
   categories: interfaces programming


### PR DESCRIPTION
Missing "e" in "WG5: International Fortran Standards Committe" to Missing "e" in "WG5: International Fortran Standards committee"
it might seem a little odd for a spelling mistake but I wanted to contribute.

thanks and regards,
Henil Panchal