### PR TITLE
Add librsb to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -254,6 +254,13 @@
   categories: interfaces
   tags: cpp gpu opencl
 
+- name: librsb
+  url: http://librsb.sourceforge.net/
+  description: A shared memory parallel sparse matrix computations library for the Recursive Sparse Blocks format 
+  categories: numerical interfaces scientific
+  tags: openmp sparse-matrix sparse-blas linear-algebra
+  license: LGPL-3.0-or-later
+  
 # --- Compiler
 
 - name: hipfort

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -256,7 +256,7 @@
 
 - name: librsb
   url: http://librsb.sourceforge.net/
-  description: A shared memory parallel sparse matrix computations library for the Recursive Sparse Blocks format implementing the Sparse BLAS
+  description: A shared memory parallel sparse matrix computations library for the Recursive Sparse Blocks format implementing the Sparse BLAS standard
   categories: numerical interfaces scientific
   tags: linear-algebra openmp
   license: LGPL-3.0-or-later

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -256,10 +256,11 @@
 
 - name: librsb
   url: http://librsb.sourceforge.net/
-  description: A shared memory parallel sparse matrix computations library for the Recursive Sparse Blocks format 
+  description: A shared memory parallel sparse matrix computations library for the Recursive Sparse Blocks format implementing the Sparse BLAS
   categories: numerical interfaces scientific
-  tags: openmp sparse-matrix sparse-blas linear-algebra
+  tags: linear-algebra openmp
   license: LGPL-3.0-or-later
+  version: 1.3
   
 # --- Compiler
 


### PR DESCRIPTION
From the [website](http://librsb.sourceforge.net):

> librsb is a library for sparse matrix computations featuring the Recursive Sparse Blocks (RSB) matrix format. This format allows cache efficient and multi-threaded (that is, shared memory parallel) operations on large sparse matrices. The most common operations necessary to iterative solvers are available, e.g.: matrix-vector multiplication, triangular solution, rows/columns scaling, diagonal extraction / setting, blocks extraction, norm computation, formats conversion. The RSB format is especially well suited for symmetric and transposed multiplication variants. Most numerical kernels code is auto generated, and the supported numerical types can be chosen by the user at build time. librsb can also be built serially (without OpenMP parallelism), if required.
>
> librsb also implements the Sparse BLAS standard, as specified in the [[BLAS Technical Forum](http://www.netlib.org/blas/blast-forum/)] documents.

The package fulfills the required criteria:

* Relevance: complete implementation of the Sparse BLAS interface in Fortran
* Maturity: extensive testing has been done over several years
* Availability: http://librsb.sourceforge.net
* Open source: LGPL-3.0 or later
* Uniqueness: rare package for sparse matrix computations with a special storage format and one of less than a handful of Sparse BLAS implementation

cc @michelemartone, would you like to add any tags? I don't think any other [categories](https://github.com/fortran-lang/fortran-lang.org/blob/master/PACKAGES.md#github-hosted-packages) apply.
