### PR TITLE
Add pencil-code to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1176,6 +1176,13 @@
   license: GPL-2.0
   version: none
 
+- name: pencil-code
+  github: pencil-code/pencil-code
+  description: A high-order finite-difference code for compressible hydrodynamic flows with magnetic fields and particles 
+  categories: scientific
+  tags: finite-difference hydrodynamics magnetic-field particles
+  license: GPL-2.0
+
 - name: MOM6
   github: NOAA-GFDL/MOM6
   description: Modular Ocean Model

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -260,7 +260,7 @@
   categories: numerical interfaces scientific
   tags: openmp sparse-matrix sparse-blas linear-algebra
   license: LGPL-3.0-or-later
-  
+
 # --- Compiler
 
 - name: hipfort
@@ -952,6 +952,13 @@
   categories: scientific
   license: LGPL-3.0-or-later
   tags: tight-binding quantum-mechanics density-functional-theory
+
+- name: Elk
+  url: https://elk.sourceforge.io/
+  description: An all-electron full-potential linearised augmented-plane wave (LAPW) code with many advanced features
+  categories: scientific
+  license: GPL-3.0
+  tags: density-functional-theory
 
 - name: LATTE
   github: lanl/LATTE

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -254,6 +254,13 @@
   categories: interfaces
   tags: cpp gpu opencl
 
+- name: librsb
+  url: http://librsb.sourceforge.net/
+  description: A shared memory parallel sparse matrix computations library for the Recursive Sparse Blocks format 
+  categories: numerical interfaces scientific
+  tags: openmp sparse-matrix sparse-blas linear-algebra
+  license: LGPL-3.0-or-later
+  
 # --- Compiler
 
 - name: hipfort


### PR DESCRIPTION
Addresses https://github.com/fortran-lang/fortran-lang.org/issues/232#issuecomment-830793321

Project homepage: http://pencil-code.nordita.org/

~~Is it okay to have both `github` and `url` fields?~~ (no need)

Elk (#390) and librsb (#389) are considered in separate pull requests.