### PR TITLE
Add PROPACK to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1176,6 +1176,13 @@
   license: GPL-2.0
   version: none
 
+- name: pencil-code
+  github: pencil-code/pencil-code
+  description: A high-order finite-difference code for compressible hydrodynamic flows with magnetic fields and particles 
+  categories: scientific
+  tags: finite-difference hydrodynamics magnetic-field particles
+  license: GPL-2.0
+
 - name: MOM6
   github: NOAA-GFDL/MOM6
   description: Modular Ocean Model

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -260,7 +260,7 @@
   categories: numerical interfaces scientific
   tags: openmp sparse-matrix sparse-blas linear-algebra
   license: LGPL-3.0-or-later
-  
+
 # --- Compiler
 
 - name: hipfort
@@ -952,6 +952,13 @@
   categories: scientific
   license: LGPL-3.0-or-later
   tags: tight-binding quantum-mechanics density-functional-theory
+
+- name: Elk
+  url: https://elk.sourceforge.io/
+  description: An all-electron full-potential linearised augmented-plane wave (LAPW) code with many advanced features
+  categories: scientific
+  license: GPL-3.0
+  tags: density-functional-theory
 
 - name: LATTE
   github: lanl/LATTE

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -254,6 +254,13 @@
   categories: interfaces
   tags: cpp gpu opencl
 
+- name: librsb
+  url: http://librsb.sourceforge.net/
+  description: A shared memory parallel sparse matrix computations library for the Recursive Sparse Blocks format 
+  categories: numerical interfaces scientific
+  tags: openmp sparse-matrix sparse-blas linear-algebra
+  license: LGPL-3.0-or-later
+  
 # --- Compiler
 
 - name: hipfort

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -712,6 +712,13 @@
   tags: blas linear-algebra
   license: BSD-3-Clause
 
+- name: PROPACK
+  url: http://sun.stanford.edu/~rmunk/PROPACK/
+  description: Software package for computing the singular value decomposition of large and sparse or structured matrices
+  categories: numerical
+  tags: linear-algebra svd lanczos-bidiagonalization openmp
+  license: BSD-3-Clause
+
 - name: ElmerFEM
   github: ElmerCSC/elmerfem
   description: Finite element software for numerical solution of partial differential equations

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -718,6 +718,7 @@
   categories: numerical
   tags: linear-algebra svd lanczos-bidiagonalization openmp
   license: BSD-3-Clause
+  version: 2.1
 
 - name: ElmerFEM
   github: ElmerCSC/elmerfem


### PR DESCRIPTION
Addresses a subtask in https://github.com/fortran-lang/fortran-lang.org/issues/232

Project homepage: http://sun.stanford.edu/~rmunk/PROPACK/

[PROPACK was recently added to SciPy](https://github.com/scipy/scipy/releases) as one of the available SVD solvers.

Note pencil-code, Elk, and librsb, are handled in other pull requests.