### PR TITLE
Add 2DECOMP&FFT to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -965,6 +965,14 @@
   description: Solver for the incompressible Navier-Stokes equations 
   categories: numerical
 
+- name: 2DECOMP&FFT
+  url: http://www.2decomp.org/
+  description: Library for 2D pencil decomposition and distributed Fast Fourier Transform
+  categories: numerical scientific
+  tags: fft parallel distributed-memory openmpi
+  license: BSD-3-Clause
+  version: 1.5.847
+
 # --- Scientific codes ---
 
 - name: "DFTB+"

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -721,12 +721,17 @@
   version: 2.1
 
 - name: FATODE
-  github: https://github.com/ComputationalScienceLaboratory/FATODE
+  github: ComputationalScienceLaboratory/FATODE
   description: A Fortran library for the integration of ordinary differential equations with direct and adjoint sensitivity analysis capabilities
   categories: numerical scientific
   tags: ode-solver
   license: GPL-3.0
   version: 1.2
+
+- name: SLICOT
+  github: SLICOT/SLICOT-Reference
+  description: A Fortran subroutines library for systems and control
+  categories: numerical scientific
 
 - name: ElmerFEM
   github: ElmerCSC/elmerfem

--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -720,6 +720,14 @@
   license: BSD-3-Clause
   version: 2.1
 
+- name: FATODE
+  github: https://github.com/ComputationalScienceLaboratory/FATODE
+  description: A Fortran library for the integration of ordinary differential equations with direct and adjoint sensitivity analysis capabilities
+  categories: numerical scientific
+  tags: ode-solver
+  license: GPL-3.0
+  version: 1.2
+
 - name: ElmerFEM
   github: ElmerCSC/elmerfem
   description: Finite element software for numerical solution of partial differential equations


### PR DESCRIPTION
Homepage: http://www.2decomp.org/

cc @ThemosTsikas, are there any tags (keywords) you'd like to see from NAG's perspective? (For more context, the aim the pull request is to add 2DECOMP to the [Fortran Package Index](https://fortran-lang.org/packages/) at fortran-lang.org; the criteria for a package to be indexed are specified [here](https://github.com/fortran-lang/fortran-lang.org/blob/master/PACKAGES.md))

Note that entries other than 2Decomp are handled in separate pull requests.
