### PR TITLE
Add OpenFFT to package index

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -937,6 +937,14 @@
   description: Solver for the incompressible Navier-Stokes equations 
   categories: numerical
 
+- name: OpenFFT
+  url: http://www.openmx-square.org/openfft/
+  description:  Open source parallel package for computing multi-dimensional Fast Fourier Transforms (3-D and 4-D FFTs)
+  categories: numerical interfaces
+  tags: fft openmpi domain-decomposition-method
+  license: GPL-3.0-or-later
+  version: 1.2
+
 # --- Scientific codes ---
 
 - name: "DFTB+"


### PR DESCRIPTION
Homepage: http://www.openmx-square.org/openfft/

The code is written in C but includes a Fortran interface. The library is used for DFT electronic structure calculation as part of the OpenMX (http://www.openmx-square.org/) library.