### PR TITLE
Add feed link to HTML head element

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{site.description}}">
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+    <link type="application/atom+xml" rel="alternate" href="{{ site.baseurl }}/news.xml" title="Fortran Newsletter" />
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/themes/smoothness/jquery-ui.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.0/normalize.min.css" rel="stylesheet">


### PR DESCRIPTION
Having the news feed linked in the `<head>` element makes it easier to subscribe in some software, as they can automatically detect the address of the feed this way. I’ve used the title “Fortran Newsletter” that’s also used for the feed itself .