### PR TITLE
fix dependency of include files under `learn/building_programs` mini-book

### DIFF
--- a/learn/building_programs/project_make.md
+++ b/learn/building_programs/project_make.md
@@ -262,7 +262,7 @@ $2 ~ /^["'].+["']$/ {
     # count included files per file to avoid having duplicates in our list
     if (incc[FILENAME,$2]++ == 0) {
         # Add the included file to our list, this might be case-sensitive
-        inc[++ii] = sprintf("$(%s) += %s", FILENAME, $2)
+        inc[++ii] = sprintf("$(%s) += $(%s)", FILENAME, $2)
     }
 }
 

--- a/learn/building_programs/project_make.md
+++ b/learn/building_programs/project_make.md
@@ -228,7 +228,7 @@ BEGIN {
 # - the first argument ($1) should be the whole word module
 # - the second argument ($2) should be a valid module name
 $1 ~ /^module$/ &&
-$2 ~ /^[a-zA-Z][a-zA-Z1-9_]*$/ {
+$2 ~ /^[a-zA-Z][a-zA-Z0-9_]*$/ {
     # count module names per file to avoid having modules twice in our list
     if (modc[FILENAME,$2]++ == 0) {
         # add to the module list, the generated module name is expected
@@ -241,7 +241,7 @@ $2 ~ /^[a-zA-Z][a-zA-Z1-9_]*$/ {
 # - the first argument ($1) should be the whole word use
 # - the second argument ($2) should be a valid module name
 $1 ~ /^use$/ &&
-$2 ~ /^[a-zA-Z][a-zA-Z1-9_]*,?$/ {
+$2 ~ /^[a-zA-Z][a-zA-Z0-9_]*,?$/ {
     # Remove a trailing comma from an optional only statement
     gsub(/,/, "", $2)
     # count used module names per file to avoid using modules twice in our list


### PR DESCRIPTION
I had to do this fix to the dependencies generator, to be able to build a project in the case when the makefile is not in the same directory as the source files. I hope this makes sense!