### PR TITLE
added QNSTOP and VTMOP (open source ACM TOMS algs from Dr. Watson's l…

### DIFF
--- a/_data/package_index.yml
+++ b/_data/package_index.yml
@@ -1488,4 +1488,18 @@
   tags: configuration yaml
   license: Apache-2.0
 
+- name: VTMOP
+  github: vtopt/VTMOP
+  description: Solver for Blackbox Multiobjective Optimization Problems.
+  categories: numerical
+  tags: global-optimization simulation-optimization blackbox-optimization multiobjective-optimization multicriteria-optimization response-surface-methodology acm-toms
+  license: MIT
+  version: none
 
+- name: QNSTOP
+  github: vtopt/qnstop
+  description: Quasi-Newton Algorithm for Stochastic Optimization.
+  categories: numerical
+  tags: quasi-newton-optimization stochastic-optimization acm-toms
+  license: MIT
+  version: none


### PR DESCRIPTION
Added QNSTOP and VTMOP (open source, peer-reviewed, ACM TOMS algorithms) to package index.

These 2 packages are released under MIT license.

But there are other repos in vtopt, that meet all of the criteria but are published under ACM TOMS license (prior to 2011, all ACM TOMS packages carried these ACM Software License).  Not sure if it is open source compatible, but based on a couple clauses, I am afraid not.

Here is an example:
  https://github.com/vtopt/vtdirect95/blob/master/LICENSE

Let me know if this license is OK, and I might be able to add several older packages as well, such as:
 - hompack90
 - vtdirect95
 - sheppack
 - polsys_plp
 - polsys_glp