### PR TITLE
announcement banner for the new site of fortran-lang.org

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,7 +15,7 @@
 	<section class="front-section shaded purple"><div class="container">
 		
 		<h5>
-		We will be migrating to a new webpage soon. Pkease checkout issue <a href="https://github.com/fortran-lang/fortran-lang.org/issue/415" target="_blank">#415</a> and the <a href="https://github.com/fortran-lang/webpage" target="_blank">new repository</a> for details on the migration.
+		We will be migrating to a new webpage soon. Please checkout issue <a href="https://github.com/fortran-lang/fortran-lang.org/issue/415" target="_blank">#415</a> and the <a href="https://github.com/fortran-lang/webpage" target="_blank">new repository</a> for details on the migration.
 		</h5>
 	</div></section>
     <div class="container">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,7 +15,7 @@
 	<section class="front-section shaded purple"><div class="container">
 		
 		<h5>
-		Please target the new repository at https://github.com/fortran-lang/webpage for any new submissions for the package index. See #415 for details on the migration.
+		Please target the new repository at https://github.com/fortran-lang/webpage for any new PR submissions. See #415 for details on the migration.
 		</h5>
 	</div></section>
     <div class="container">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,7 +15,7 @@
 	<section class="front-section shaded purple"><div class="container">
 		
 		<h5>
-		Please target the new repository at https://github.com/fortran-lang/webpage for any new PR submissions. See #415 for details on the migration.
+		We will be migrating to a new webpage soon. Pkease checkout issue <a href="https://github.com/fortran-lang/fortran-lang.org/issue/415" target="_blank">#415</a> and the <a href="https://github.com/fortran-lang/webpage" target="_blank">new repository</a> for details on the migration.
 		</h5>
 	</div></section>
     <div class="container">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -14,9 +14,9 @@
 	{% endif %} 
 	<section class="front-section shaded purple"><div class="container">
 		
-		<h5>
-		We will be migrating to a new webpage soon. Please checkout issue <a href="https://github.com/fortran-lang/fortran-lang.org/issue/415" target="_blank">#415</a> and the <a href="https://github.com/fortran-lang/webpage" target="_blank">new repository</a> for details on the migration.
-		</h5>
+		<h4>
+		We will be migrating to a new webpage soon. Please checkout issue <a href="https://github.com/fortran-lang/fortran-lang.org/issues/415" target="_blank">#415</a> and the <a href="https://github.com/fortran-lang/webpage" target="_blank">new repository</a> for details on the migration.
+		</h4>
 	</div></section>
     <div class="container">
         <nav class="navbar">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -12,6 +12,12 @@
 		</h3>
 	</div></section>
 	{% endif %} 
+	<section class="front-section shaded purple"><div class="container">
+		
+		<h5>
+		Please target the new repository at https://github.com/fortran-lang/webpage for any new submissions for the package index. See #415 for details on the migration.
+		</h5>
+	</div></section>
     <div class="container">
         <nav class="navbar">
 	    <div class="container-fluid">


### PR DESCRIPTION
As We are planning to finish the migration by end of next week. we would like to add a banner to the current page to make visitors aware of the upcoming migration.

Once we migrated to the sphinx based webpage this repository will be available at the default GH pages URL https://fortran-lang.github.io/fortran-lang.org and we will create a banner on the new webpage referencing the old repository in case somebody finds something missing.

Preview available at https://fortran-lang.org/pr/418/

Thanks and Regards,
Henil Shalin Panchal

CC @awvwgk 