### PR TITLE
fix canonical links for crawlers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ news:
     url: /news
     feed: /news.xml
 
-url: "https://fortran-lang.github.io"
+url: "https://fortran-lang.org"
 
 plugins:
 


### PR DESCRIPTION
This PR is to resolve https://github.com/fortran-lang/webpage/issues/222 , Please refer : https://fortran-lang.discourse.group/t/4942 .

This would add a custom canonical link tag to all the pages of the webpage.

Thanks and Regards,
Henil

CC @awvwgk @certik